### PR TITLE
Ci/stay on docker node lts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,22 +32,9 @@ updates:
 
   ##### Docker #####
   - package-ecosystem: "docker"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    groups:
-      update-docker-dependencies:
-        patterns:
-          - "*"
-    reviewers:
-      - "jkoenig134"
-      - "sebbi08"
-    labels:
-      - "dependencies"
-
-  ##### Docker #####
-  - package-ecosystem: "docker"
-    directory: "/.dev"
+    directories:
+      - "/"
+      - "/.dev"
     schedule:
       interval: "weekly"
     groups:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,6 +41,10 @@ updates:
       update-docker-dependencies:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "node"
+        versions:
+          - ">20"
     reviewers:
       - "jkoenig134"
       - "sebbi08"


### PR DESCRIPTION
LTS will not change [until October](https://nodejs.org/en/about/previous-releases). But we need a better long-term solution for that.