### PR TITLE
Allow skipping the tls check for webhooks

### DIFF
--- a/src/modules/messageBrokerPublisher/connectors/MessageBrokerConnector.ts
+++ b/src/modules/messageBrokerPublisher/connectors/MessageBrokerConnector.ts
@@ -4,7 +4,9 @@ export abstract class MessageBrokerConnector<TConfiguration> {
     public constructor(
         protected readonly configuration: TConfiguration,
         protected readonly logger: ILogger
-    ) {}
+    ) {
+        if (!this.configuration) throw new Error("Cannot start the broker, the 'configuration' is not defined.");
+    }
 
     public abstract init(): void | Promise<void>;
     public abstract publish(namespace: string, data: Buffer): void | Promise<void>;

--- a/src/modules/webhooks/ConfigModel.ts
+++ b/src/modules/webhooks/ConfigModel.ts
@@ -2,7 +2,10 @@ import { Result } from "@js-soft/ts-utils";
 import { WebhooksModuleApplicationErrors } from "./WebhooksModuleApplicationErrors";
 
 export class ConfigModel {
-    public constructor(public readonly webhooks: Webhook[]) {}
+    public constructor(
+        public readonly webhooks: Webhook[],
+        public readonly skipTlsCheck: boolean
+    ) {}
 }
 
 export class Webhook {

--- a/src/modules/webhooks/ConfigParser.ts
+++ b/src/modules/webhooks/ConfigParser.ts
@@ -14,7 +14,7 @@ export class ConfigParser {
             return Result.fail(webhooks.error);
         }
 
-        const configModel = new ConfigModel(webhooks.value);
+        const configModel = new ConfigModel(webhooks.value, configJson.skipTlsCheck ?? false);
         return Result.ok(configModel);
     }
 

--- a/src/modules/webhooks/WebhooksModule.ts
+++ b/src/modules/webhooks/WebhooksModule.ts
@@ -12,14 +12,14 @@ export default class WebhooksModule extends ConnectorRuntimeModule<WebhooksModul
     private configModel: ConfigModel;
 
     public init(): void {
+        this.configModel = ConfigParser.parse(this.configuration).value;
+
         this.axios = axios.create({
             httpAgent: new agentKeepAlive(),
-            httpsAgent: new AgentKeepAliveHttps(),
+            httpsAgent: new AgentKeepAliveHttps({ rejectUnauthorized: !this.configModel.skipTlsCheck }),
             validateStatus: () => true,
             maxRedirects: 0
         });
-
-        this.configModel = ConfigParser.parse(this.configuration).value;
     }
 
     public start(): void {

--- a/src/modules/webhooks/WebhooksModuleConfiguration.ts
+++ b/src/modules/webhooks/WebhooksModuleConfiguration.ts
@@ -3,6 +3,7 @@ import { ConnectorRuntimeModuleConfiguration } from "../../ConnectorRuntimeModul
 export interface WebhooksModuleConfiguration extends ConnectorRuntimeModuleConfiguration {
     targets?: Record<string, WebhooksModuleConfigurationTarget>;
     webhooks?: WebhooksModuleConfigurationWebhook[];
+    skipTlsCheck?: boolean;
 }
 
 export interface WebhooksModuleConfigurationTarget {


### PR DESCRIPTION
At some points it can be that services run under a self signed certificate. The only option at the moment is to turn of certificate validation **globally** using the `NODE_TLS_REJECT_UNAUTHORIZED` environment variable which also disables the tls check when accessing the backbone.

Now it is possible to disable tls checks for the webhooks module.

# Readiness checklist

-   [ ] I added/updated tests.
-   [x] I ensured that the PR title is good enough for the changelog.
-   [x] I labeled the PR.
