### PR TITLE
Fix socket hangups during debugging of tests

### DIFF
--- a/test/lib/Launcher.ts
+++ b/test/lib/Launcher.ts
@@ -3,7 +3,9 @@ import { ConnectorClient } from "@nmshd/connector-sdk";
 import { Random, RandomCharacterRange } from "@nmshd/transport";
 import { ChildProcess, spawn } from "child_process";
 import express from "express";
-import { Server } from "http";
+import http, { Server } from "node:http";
+import https from "node:https";
+import inspector from "node:inspector";
 import path from "path";
 import { MockEventBus } from "./MockEventBus";
 import getPort from "./getPort";
@@ -43,10 +45,17 @@ export class Launcher {
         const ports: number[] = [];
         const startPromises: Promise<void>[] = [];
 
+        const debugging = !!inspector.url();
         for (let i = 0; i < count; i++) {
             const port = await getPort();
             const accountName = `${i + 1}-${await this.randomString()}`;
-            const connectorClient = ConnectorClient.create({ baseUrl: `http://localhost:${port}`, apiKey: this.apiKey }) as ConnectorClientWithMetadata;
+
+            const connectorClient = ConnectorClient.create({
+                baseUrl: `http://localhost:${port}`,
+                apiKey: this.apiKey,
+                httpAgent: debugging ? new http.Agent({ keepAlive: false }) : undefined,
+                httpsAgent: debugging ? new https.Agent({ keepAlive: false }) : undefined
+            }) as ConnectorClientWithMetadata;
             connectorClient["_metadata"] = { accountName: `acc-${accountName}` };
 
             connectorClient._eventBus = new MockEventBus();


### PR DESCRIPTION
Not reusing sockets gets rid of socket hangups during debugging when a connection times out and is closed by the server while the event loop is frozen.

# Readiness checklist

-   [x] I added/updated tests.
-   [x] I ensured that the PR title is good enough for the changelog.
-   [x] I labeled the PR.
