### PR TITLE
Use `@nmshd/typescript-ioc` and `@nmshd/typescript-rest` to get rid of vulnerabilities

### DIFF
--- a/.ci/runChecks.sh
+++ b/.ci/runChecks.sh
@@ -11,4 +11,4 @@ npm run lint:prettier
 
 # auditing
 npx license-check --ignoreRegex @nmshd/connector
-npx better-npm-audit audit --exclude 1096302,1093639
+npx better-npm-audit audit

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
                 "@js-soft/docdb-access-mongo": "1.1.9",
                 "@js-soft/node-logger": "1.2.0",
                 "@js-soft/ts-utils": "^2.3.3",
-                "@nmshd/runtime": "6.3.0",
+                "@nmshd/runtime": "6.3.1",
+                "@nmshd/typescript-ioc": "^3.2.4",
                 "agentkeepalive": "4.5.0",
                 "amqplib": "^0.10.4",
                 "axios": "^1.7.7",
@@ -29,16 +30,12 @@
                 "json-stringify-safe": "5.0.1",
                 "jsonschema": "1.4.1",
                 "mqtt": "^5.10.1",
-                "multer": "^1.4.5-lts.1",
                 "nconf": "0.12.1",
                 "on-headers": "1.0.2",
                 "rapidoc": "9.3.8",
                 "redis": "^4.7.0",
                 "reflect-metadata": "0.2.2",
                 "swagger-ui-express": "5.0.1",
-                "typescript-ioc": "3.2.2",
-                "typescript-rest": "3.0.4",
-                "typescript-rest-ioc": "1.0.1",
                 "yamljs": "0.3.0"
             },
             "devDependencies": {
@@ -46,8 +43,9 @@
                 "@js-soft/eslint-config-ts": "1.6.12",
                 "@js-soft/license-check": "1.0.9",
                 "@nmshd/connector-sdk": "*",
-                "@nmshd/content": "6.3.0",
-                "@nmshd/core-types": "6.3.0",
+                "@nmshd/content": "6.3.1",
+                "@nmshd/core-types": "6.3.1",
+                "@nmshd/typescript-rest-swagger": "^1.4.1",
                 "@types/amqplib": "^0.10.5",
                 "@types/compression": "^1.7.5",
                 "@types/cors": "^2.8.17",
@@ -76,8 +74,7 @@
                 "prettier": "^3.3.3",
                 "ts-jest": "^29.2.5",
                 "ts-node": "^10.9.2",
-                "typescript": "^5.6.3",
-                "typescript-rest-swagger": "github:nmshd/typescript-rest-swagger#1.4.0"
+                "typescript": "^5.6.3"
             }
         },
         "node_modules/@acuminous/bitsyntax": {
@@ -963,13 +960,6 @@
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             }
-        },
-        "node_modules/@exodus/schemasafe": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/@exodus/schemasafe/-/schemasafe-1.3.0.tgz",
-            "integrity": "sha512-5Aap/GaRupgNx/feGBwLLTVv8OQFfv3pq2lPRzPg9R+IOBnDgghTGW7l7EuVXOvg5cc/xSAlRW8rBrjIC3Nvqw==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/@google-cloud/paginator": {
             "version": "5.0.2",
@@ -2022,39 +2012,39 @@
             "link": true
         },
         "node_modules/@nmshd/consumption": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/@nmshd/consumption/-/consumption-6.3.0.tgz",
-            "integrity": "sha512-4uvngBsoPGWAQixvKVi/yAJ76el/5p0GQl90C4vhV4fJfEzI43gpXnR24l3clCFSYmQvJ+QYxtpuenvKlrV5RA==",
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/@nmshd/consumption/-/consumption-6.3.1.tgz",
+            "integrity": "sha512-5WoMLYK22OymCOHT4BvRjhTHu6PluSSkFaAp81ZsKSCjmFv9zArTyja5AX8YQQ3FWDql78Ecgv7dnFV/18cupQ==",
             "license": "MIT",
             "dependencies": {
                 "@js-soft/docdb-querytranslator": "^1.1.5",
                 "@js-soft/ts-serval": "2.0.11",
                 "@js-soft/ts-utils": "2.3.3",
-                "@nmshd/content": "6.3.0",
-                "@nmshd/core-types": "6.3.0",
+                "@nmshd/content": "6.3.1",
+                "@nmshd/core-types": "6.3.1",
                 "@nmshd/iql": "^1.0.2",
-                "@nmshd/transport": "6.3.0",
+                "@nmshd/transport": "6.3.1",
                 "lodash": "^4.17.21",
                 "ts-simple-nameof": "^1.3.1"
             }
         },
         "node_modules/@nmshd/content": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/@nmshd/content/-/content-6.3.0.tgz",
-            "integrity": "sha512-ok0li6yPSwp7KfXy8cyyZBGpN8GCu1/p5M3e08MZ6IC4NPPUcg3QCRJ0+YNb2eF0AvZSF/dnWzQG1nevzNO3dQ==",
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/@nmshd/content/-/content-6.3.1.tgz",
+            "integrity": "sha512-p7xxu8QWCn68XYDhjyLCb9J8HK72xDwLKKdutG9JbSfWUenK2MhaZeiBkVqNJmo5rPuNz3ir6kcpfSQvZbqq2A==",
             "license": "MIT",
             "dependencies": {
                 "@js-soft/ts-serval": "2.0.11",
-                "@nmshd/core-types": "6.3.0",
+                "@nmshd/core-types": "6.3.1",
                 "@nmshd/iql": "^1.0.2",
                 "luxon": "^3.5.0",
                 "ts-simple-nameof": "^1.3.1"
             }
         },
         "node_modules/@nmshd/core-types": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/@nmshd/core-types/-/core-types-6.3.0.tgz",
-            "integrity": "sha512-Hd2m91rrYCPAGk69YoDjkHlVeHR22J+6pHYB+F4VcZETRlZhqmQ9VVjpBqHob69qygTyWPZTaju5dmfyrTp32Q==",
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/@nmshd/core-types/-/core-types-6.3.1.tgz",
+            "integrity": "sha512-+io2ReRZZ9GAp1AhjyFPo0KM9Cuthm9aOgXlBt5IEspFUevXtjmkaJBvCFv/HM8zo5eQnKVZ8i8JJLgHU/uhiw==",
             "license": "MIT",
             "dependencies": {
                 "@js-soft/logging-abstractions": "^1.0.1",
@@ -2093,21 +2083,22 @@
             "license": "MIT"
         },
         "node_modules/@nmshd/runtime": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/@nmshd/runtime/-/runtime-6.3.0.tgz",
-            "integrity": "sha512-cASBdb4/5PK9pIArNzTCszzxOGp83zRafKNyLBFrtSDIdPu3OmgYaFGFWgGBsHJdViUb1qxkapBMrrREbw/5JA==",
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/@nmshd/runtime/-/runtime-6.3.1.tgz",
+            "integrity": "sha512-PLT7OjZJmnr8xrMz+k7sgOhbQRtxxcL7sPNDzvRXLGGZEZxjkWnDoIu5mWoOTYaxuA1e6PjY5nhnju0TKZGvsw==",
             "license": "MIT",
             "dependencies": {
                 "@js-soft/docdb-querytranslator": "^1.1.5",
                 "@js-soft/logging-abstractions": "^1.0.1",
                 "@js-soft/ts-serval": "2.0.11",
                 "@js-soft/ts-utils": "^2.3.3",
-                "@nmshd/consumption": "6.3.0",
-                "@nmshd/content": "6.3.0",
-                "@nmshd/core-types": "6.3.0",
+                "@nmshd/consumption": "6.3.1",
+                "@nmshd/content": "6.3.1",
+                "@nmshd/core-types": "6.3.1",
                 "@nmshd/crypto": "2.0.7",
                 "@nmshd/iql": "^1.0.2",
-                "@nmshd/transport": "6.3.0",
+                "@nmshd/transport": "6.3.1",
+                "@nmshd/typescript-ioc": "3.2.4",
                 "ajv": "^8.17.1",
                 "ajv-errors": "^3.0.0",
                 "ajv-formats": "^3.0.1",
@@ -2116,21 +2107,20 @@
                 "luxon": "^3.5.0",
                 "qrcode": "1.5.4",
                 "reflect-metadata": "^0.2.2",
-                "ts-simple-nameof": "^1.3.1",
-                "typescript-ioc": "3.2.2"
+                "ts-simple-nameof": "^1.3.1"
             }
         },
         "node_modules/@nmshd/transport": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/@nmshd/transport/-/transport-6.3.0.tgz",
-            "integrity": "sha512-gfrW0L1F+AkFaOazKkbrRYLXDdNnyCKKgmmJnI9bKiS0ryT7SJSu5ucsIU7ggxbk3u6Y33MTX2+luNdp0rxs9g==",
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/@nmshd/transport/-/transport-6.3.1.tgz",
+            "integrity": "sha512-kw793HfS489rMdLgUTAcH6/lOKrjQ+M5MiRNsBNp+1CQlkByk+XOdRUOZKJ1dLQ8OGehT7BKZHt4YWb1Lm5/aQ==",
             "license": "MIT",
             "dependencies": {
                 "@js-soft/docdb-access-abstractions": "1.0.4",
                 "@js-soft/logging-abstractions": "^1.0.1",
                 "@js-soft/simple-logger": "1.0.5",
                 "@js-soft/ts-utils": "^2.3.3",
-                "@nmshd/core-types": "6.3.0",
+                "@nmshd/core-types": "6.3.1",
                 "@nmshd/crypto": "2.0.7",
                 "axios": "^1.7.7",
                 "fast-json-patch": "^3.1.1",
@@ -2158,10 +2148,92 @@
                 "uuid": "dist/bin/uuid"
             }
         },
+        "node_modules/@nmshd/typescript-ioc": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/@nmshd/typescript-ioc/-/typescript-ioc-3.2.4.tgz",
+            "integrity": "sha512-CNJbsdqcI+vB9eRACB0AI1s0IL3qXfuINKwoKVP/1DhuL+leZUXAV9GcuJ68Fr3scCz/fhzQK9bWLJus66V6HQ==",
+            "license": "MIT",
+            "dependencies": {
+                "lodash": "^4.17.21",
+                "reflect-metadata": "^0.2.2"
+            }
+        },
+        "node_modules/@nmshd/typescript-rest": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@nmshd/typescript-rest/-/typescript-rest-3.0.5.tgz",
+            "integrity": "sha512-XhXwB17qT9fz8PJqUNEM/NZ0hHuFSiWEZeFnnmy0MQYcj5lAEfDOTn6y547pCwrHr6eFboB5JzfUpY7NkOa8gg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/body-parser": "1.19.5",
+                "@types/cookie-parser": "^1.4.7",
+                "@types/express": "^5.0.0",
+                "@types/multer": "1.4.12",
+                "body-parser": "^1.20.3",
+                "cookie-parser": "^1.4.7",
+                "express": "^4.21.1",
+                "fs-extra": "^11.2.0",
+                "lodash": "^4.17.21",
+                "multer": "^1.4.5-lts.1",
+                "reflect-metadata": "^0.2.2",
+                "require-glob": "^4.1.0",
+                "swagger-ui-express": "^5.0.1",
+                "yamljs": "^0.3.0"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@nmshd/typescript-rest-swagger": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/@nmshd/typescript-rest-swagger/-/typescript-rest-swagger-1.4.1.tgz",
+            "integrity": "sha512-23ncVQKUfor35ry31ebR3JAsODtG1wDRB48g7YYkMEdokSb9tZ64UUXG5qksXY6Tb6ptTINxhoue4lhc6zr9LQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@apidevtools/swagger-parser": "^10.1.0",
+                "@nmshd/typescript-rest": "^3.0.5",
+                "argparse": "^2.0.1",
+                "debug": "^4.3.4",
+                "fs-extra-promise": "^1.0.1",
+                "glob": "^10.3.10",
+                "lodash": "^4.17.21",
+                "merge": "^2.1.1",
+                "minimatch": "^9.0.3",
+                "openapi-types": "^12.1.3",
+                "ts-morph": "^23.0.0",
+                "typescript": "^5.5.3",
+                "yamljs": "^0.3.0"
+            },
+            "bin": {
+                "swaggerGen": "dist/cli.js"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@nmshd/typescript-rest-swagger/node_modules/argparse": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "dev": true,
+            "license": "Python-2.0"
+        },
+        "node_modules/@nmshd/typescript-rest/node_modules/@types/multer": {
+            "version": "1.4.12",
+            "resolved": "https://registry.npmjs.org/@types/multer/-/multer-1.4.12.tgz",
+            "integrity": "sha512-pQ2hoqvXiJt2FP9WQVLPRO+AmiIm/ZYkavPlIQnx282u4ZrVdztx0pkh3jjpQt0Kz+YI0YhSG264y08UJKoUQg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/express": "*"
+            }
+        },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
             "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@nodelib/fs.stat": "2.0.5",
@@ -2175,6 +2247,7 @@
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
             "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 8"
@@ -2184,6 +2257,7 @@
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
             "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@nodelib/fs.scandir": "2.1.5",
@@ -2960,6 +3034,7 @@
             "version": "1.19.5",
             "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
             "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/connect": "*",
@@ -2986,6 +3061,7 @@
             "version": "3.4.38",
             "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
             "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/node": "*"
@@ -2995,6 +3071,7 @@
             "version": "1.4.7",
             "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.7.tgz",
             "integrity": "sha512-Fvuyi354Z+uayxzIGCwYTayFKocfV7TuDYZClCdIP9ckhvAu/ixDtCB6qx2TT0FKjPLf1f3P/J1rgf6lPs64mw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/express": "*"
@@ -3021,6 +3098,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.0.tgz",
             "integrity": "sha512-DvZriSMehGHL1ZNLzi6MidnsDhUZM/x2pRdDIKdwbUNqqwHxMlRdkxtn6/EPKyqKpHqTl/4nRZsRNLpZxZRpPQ==",
+            "dev": true,
             "dependencies": {
                 "@types/body-parser": "*",
                 "@types/express-serve-static-core": "^5.0.0",
@@ -3032,6 +3110,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.0.tgz",
             "integrity": "sha512-AbXMTZGt40T+KON9/Fdxx0B2WK5hsgxcfXJLr5bFpZ7b4JCex2WyQPTEKdXqfHiY5nKKBScZ7yCoO6Pvgxfvnw==",
+            "dev": true,
             "dependencies": {
                 "@types/node": "*",
                 "@types/qs": "*",
@@ -3064,6 +3143,7 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
             "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/istanbul-lib-coverage": {
@@ -3182,16 +3262,8 @@
             "version": "1.3.5",
             "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
             "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+            "dev": true,
             "license": "MIT"
-        },
-        "node_modules/@types/multer": {
-            "version": "1.4.5",
-            "resolved": "https://registry.npmjs.org/@types/multer/-/multer-1.4.5.tgz",
-            "integrity": "sha512-9b/0a8JyrR0r2nQhL73JR86obWL7cogfX12augvlrvcpciCo/hkvEsgu80Z4S2g2DHGVXHr8pUIi1VhqFJ8Ufw==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/express": "*"
-            }
         },
         "node_modules/@types/nconf": {
             "version": "0.10.7",
@@ -3219,19 +3291,11 @@
                 "@types/node": "*"
             }
         },
-        "node_modules/@types/passport": {
-            "version": "1.0.16",
-            "resolved": "https://registry.npmjs.org/@types/passport/-/passport-1.0.16.tgz",
-            "integrity": "sha512-FD0qD5hbPWQzaM0wHUnJ/T0BBCJBxCeemtnCwc/ThhTg3x9jfrAcRUmj5Dopza+MfFS9acTe3wk7rcVnRIp/0A==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/express": "*"
-            }
-        },
         "node_modules/@types/qs": {
             "version": "6.9.16",
             "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.16.tgz",
             "integrity": "sha512-7i+zxXdPD0T4cKDuxCUXJ4wHcsJLwENa6Z3dCu8cfCK743OGy5Nu1RmAGqDPsoTDINVEcdXKRvR/zre+P2Ku1A==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/ramda": {
@@ -3245,7 +3309,8 @@
         "node_modules/@types/range-parser": {
             "version": "1.2.7",
             "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
-            "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="
+            "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+            "dev": true
         },
         "node_modules/@types/readable-stream": {
             "version": "4.0.15",
@@ -3287,6 +3352,7 @@
             "version": "0.17.4",
             "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
             "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/mime": "^1",
@@ -3297,6 +3363,7 @@
             "version": "1.15.7",
             "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.7.tgz",
             "integrity": "sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/http-errors": "*",
@@ -3828,6 +3895,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
             "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/arg": {
@@ -3883,6 +3951,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
             "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -4335,6 +4404,7 @@
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
             "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "fill-range": "^7.1.1"
@@ -4454,6 +4524,7 @@
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
             "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+            "dev": true,
             "dependencies": {
                 "streamsearch": "^1.1.0"
             },
@@ -4534,6 +4605,7 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
             "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -4964,6 +5036,7 @@
             "version": "1.4.7",
             "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
             "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "cookie": "0.7.2",
@@ -5488,6 +5561,7 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
             "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "path-type": "^4.0.0"
@@ -5800,13 +5874,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
-        },
-        "node_modules/es6-promise": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
-            "integrity": "sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/escalade": {
             "version": "3.2.0",
@@ -6377,6 +6444,7 @@
             "version": "3.3.2",
             "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
             "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@nodelib/fs.stat": "^2.0.2",
@@ -6393,6 +6461,7 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
             "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "is-glob": "^4.0.1"
@@ -6421,13 +6490,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/fast-safe-stringify": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
-            "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/fast-unique-numbers": {
             "version": "8.0.13",
             "resolved": "https://registry.npmjs.org/fast-unique-numbers/-/fast-unique-numbers-8.0.13.tgz",
@@ -6451,6 +6513,7 @@
             "version": "1.17.1",
             "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
             "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "reusify": "^1.0.4"
@@ -6506,6 +6569,7 @@
             "version": "7.1.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
             "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "to-regex-range": "^5.0.1"
@@ -6982,6 +7046,7 @@
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
             "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "is-glob": "^4.0.3"
@@ -7039,6 +7104,7 @@
             "version": "11.1.0",
             "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
             "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "array-union": "^2.1.0",
@@ -7309,13 +7375,6 @@
                 "node": ">= 6.0.0"
             }
         },
-        "node_modules/http2-client": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/http2-client/-/http2-client-1.3.5.tgz",
-            "integrity": "sha512-EC2utToWl4RKfs5zd36Mxq7nzHHBuomZboI0yYL6Y0RmBgT7Sgkq4rQ0ezFTYoIsSs7Tm9SJe+o2FcAg6GBhGA==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/https-proxy-agent": {
             "version": "7.0.5",
             "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
@@ -7384,6 +7443,7 @@
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
             "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 4"
@@ -7625,6 +7685,7 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
             "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -7653,6 +7714,7 @@
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
             "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "is-extglob": "^2.1.1"
@@ -7678,6 +7740,7 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.12.0"
@@ -8877,6 +8940,7 @@
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
             "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "universalify": "^2.0.0"
@@ -9200,12 +9264,6 @@
             "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
             "license": "MIT"
         },
-        "node_modules/lodash.get": {
-            "version": "4.4.2",
-            "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-            "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
-            "license": "MIT"
-        },
         "node_modules/lodash.memoize": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -9218,12 +9276,6 @@
             "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
             "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
             "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/lodash.set": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
-            "integrity": "sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg==",
             "license": "MIT"
         },
         "node_modules/lodash.snakecase": {
@@ -9375,6 +9427,7 @@
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
             "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 8"
@@ -9393,6 +9446,7 @@
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
             "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "braces": "^3.0.3",
@@ -9516,6 +9570,7 @@
             "version": "0.5.6",
             "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
             "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "minimist": "^1.2.6"
@@ -9690,6 +9745,7 @@
             "version": "1.4.5-lts.1",
             "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.5-lts.1.tgz",
             "integrity": "sha512-ywPWvcDMeH+z9gQq5qYHCCy+ethsk4goepZ45GLD63fOu0YcNecQxi64nDs3qluZB+murG3/D4dJ7+dGctcCQQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "append-field": "^1.0.0",
@@ -9708,6 +9764,7 @@
             "version": "1.6.2",
             "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
             "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+            "dev": true,
             "engines": [
                 "node >= 0.8"
             ],
@@ -9723,12 +9780,14 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
             "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/multer/node_modules/readable-stream": {
             "version": "2.3.8",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
             "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "core-util-is": "~1.0.0",
@@ -9744,6 +9803,7 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "safe-buffer": "~5.1.0"
@@ -9953,19 +10013,6 @@
                 "url": "https://opencollective.com/node-fetch"
             }
         },
-        "node_modules/node-fetch-h2": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/node-fetch-h2/-/node-fetch-h2-2.3.0.tgz",
-            "integrity": "sha512-ofRW94Ab0T4AOh5Fk8t0h8OBWrmjb0SSB20xh1H8YnPV9EJ+f5AMoYSUQ2zgJ4Iq2HAK0I2l5/Nequ8YzFS3Hg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "http2-client": "^1.2.5"
-            },
-            "engines": {
-                "node": "4.x || >=6.0.0"
-            }
-        },
         "node_modules/node-fetch/node_modules/tr46": {
             "version": "0.0.3",
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -9994,16 +10041,6 @@
             "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/node-readfiles": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/node-readfiles/-/node-readfiles-0.2.0.tgz",
-            "integrity": "sha512-SU00ZarexNlE4Rjdm83vglt5Y9yiQ+XI1XpflWlb7q7UTN1JUItm69xMeiQCTxtTfnzt+83T8Cx+vI2ED++VDA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "es6-promise": "^3.2.1"
-            }
         },
         "node_modules/node-releases": {
             "version": "2.0.18",
@@ -10366,81 +10403,6 @@
                 "js-sdsl": "4.3.0"
             }
         },
-        "node_modules/oas-kit-common": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/oas-kit-common/-/oas-kit-common-1.0.8.tgz",
-            "integrity": "sha512-pJTS2+T0oGIwgjGpw7sIRU8RQMcUoKCDWFLdBqKB2BNmGpbBMH2sdqAaOXUg8OzonZHU0L7vfJu1mJFEiYDWOQ==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "fast-safe-stringify": "^2.0.7"
-            }
-        },
-        "node_modules/oas-linter": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/oas-linter/-/oas-linter-3.2.2.tgz",
-            "integrity": "sha512-KEGjPDVoU5K6swgo9hJVA/qYGlwfbFx+Kg2QB/kd7rzV5N8N5Mg6PlsoCMohVnQmo+pzJap/F610qTodKzecGQ==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "@exodus/schemasafe": "^1.0.0-rc.2",
-                "should": "^13.2.1",
-                "yaml": "^1.10.0"
-            },
-            "funding": {
-                "url": "https://github.com/Mermade/oas-kit?sponsor=1"
-            }
-        },
-        "node_modules/oas-resolver": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/oas-resolver/-/oas-resolver-2.5.6.tgz",
-            "integrity": "sha512-Yx5PWQNZomfEhPPOphFbZKi9W93CocQj18NlD2Pa4GWZzdZpSJvYwoiuurRI7m3SpcChrnO08hkuQDL3FGsVFQ==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "node-fetch-h2": "^2.3.0",
-                "oas-kit-common": "^1.0.8",
-                "reftools": "^1.1.9",
-                "yaml": "^1.10.0",
-                "yargs": "^17.0.1"
-            },
-            "bin": {
-                "resolve": "resolve.js"
-            },
-            "funding": {
-                "url": "https://github.com/Mermade/oas-kit?sponsor=1"
-            }
-        },
-        "node_modules/oas-schema-walker": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/oas-schema-walker/-/oas-schema-walker-1.1.5.tgz",
-            "integrity": "sha512-2yucenq1a9YPmeNExoUa9Qwrt9RFkjqaMAA1X+U7sbb0AqBeTIdMHky9SQQ6iN94bO5NW0W4TRYXerG+BdAvAQ==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "funding": {
-                "url": "https://github.com/Mermade/oas-kit?sponsor=1"
-            }
-        },
-        "node_modules/oas-validator": {
-            "version": "5.0.8",
-            "resolved": "https://registry.npmjs.org/oas-validator/-/oas-validator-5.0.8.tgz",
-            "integrity": "sha512-cu20/HE5N5HKqVygs3dt94eYJfBi0TsZvPVXDhbXQHiEityDN+RROTleefoKRKKJ9dFAF2JBkDHgvWj0sjKGmw==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "call-me-maybe": "^1.0.1",
-                "oas-kit-common": "^1.0.8",
-                "oas-linter": "^3.2.2",
-                "oas-resolver": "^2.5.6",
-                "oas-schema-walker": "^1.1.5",
-                "reftools": "^1.1.9",
-                "should": "^13.2.1",
-                "yaml": "^1.10.0"
-            },
-            "funding": {
-                "url": "https://github.com/Mermade/oas-kit?sponsor=1"
-            }
-        },
         "node_modules/object-assign": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -10735,37 +10697,6 @@
                 "node": ">= 0.8"
             }
         },
-        "node_modules/passport": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/passport/-/passport-0.4.1.tgz",
-            "integrity": "sha512-IxXgZZs8d7uFSt3eqNjM9NQ3g3uQCW5avD8mRNoXV99Yig50vjuaez6dQK2qC0kVWPRTujxY0dWgGfT09adjYg==",
-            "license": "MIT",
-            "dependencies": {
-                "passport-strategy": "1.x.x",
-                "pause": "0.0.1"
-            },
-            "engines": {
-                "node": ">= 0.4.0"
-            }
-        },
-        "node_modules/passport-strategy": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
-            "integrity": "sha512-CB97UUvDKJde2V0KDWWB3lyf6PC3FaZP7YxZ2G8OAtn9p4HI9j9JLP9qjOGZFvyl8uwNT8qM+hGnz/n16NI7oA==",
-            "engines": {
-                "node": ">= 0.4.0"
-            }
-        },
-        "node_modules/path": {
-            "version": "0.12.7",
-            "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
-            "integrity": "sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==",
-            "license": "MIT",
-            "dependencies": {
-                "process": "^0.11.1",
-                "util": "^0.10.3"
-            }
-        },
         "node_modules/path-browserify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
@@ -10842,15 +10773,11 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
             "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
-        },
-        "node_modules/pause": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
-            "integrity": "sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg=="
         },
         "node_modules/picocolors": {
             "version": "1.1.0",
@@ -10863,6 +10790,7 @@
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
             "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8.6"
@@ -11388,6 +11316,7 @@
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
             "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -11716,16 +11645,6 @@
             "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
             "license": "Apache-2.0"
         },
-        "node_modules/reftools": {
-            "version": "1.1.9",
-            "resolved": "https://registry.npmjs.org/reftools/-/reftools-1.1.9.tgz",
-            "integrity": "sha512-OVede/NQE13xBQ+ob5CKd5KyeJYU2YInb1bmV4nRoOfquZPkAkxuOXicSe1PvqIuZZ4kD13sPKBbR7UFDmli6w==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "funding": {
-                "url": "https://github.com/Mermade/oas-kit?sponsor=1"
-            }
-        },
         "node_modules/regenerator-runtime": {
             "version": "0.14.1",
             "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
@@ -11788,6 +11707,7 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/require-glob/-/require-glob-4.1.0.tgz",
             "integrity": "sha512-c66YRk0kDUUz9t+/nEG11dnVh6nLppztiE/TLBerRlAGd75AuCLXHQ6xauOPgZaw9T+6wfG8u8ibfMD9GwmDYw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "glob-parent": "^6.0.0",
@@ -11802,6 +11722,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-2.0.0.tgz",
             "integrity": "sha512-uo0Z9JJeWzv8BG+tRcapBKNJ0dro9cLyczGzulS6EfeyAdeC9sbojtW6XwvYxJkEne9En+J2XEl4zyglVeIwFg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "callsites": "^3.1.0"
@@ -11910,6 +11831,7 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
             "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "iojs": ">=1.0.0",
@@ -11989,6 +11911,7 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
             "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -12243,66 +12166,6 @@
                 "suid": "bin/short-unique-id"
             }
         },
-        "node_modules/should": {
-            "version": "13.2.3",
-            "resolved": "https://registry.npmjs.org/should/-/should-13.2.3.tgz",
-            "integrity": "sha512-ggLesLtu2xp+ZxI+ysJTmNjh2U0TsC+rQ/pfED9bUZZ4DKefP27D+7YJVVTvKsmjLpIi9jAa7itwDGkDDmt1GQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "should-equal": "^2.0.0",
-                "should-format": "^3.0.3",
-                "should-type": "^1.4.0",
-                "should-type-adaptors": "^1.0.1",
-                "should-util": "^1.0.0"
-            }
-        },
-        "node_modules/should-equal": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-2.0.0.tgz",
-            "integrity": "sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "should-type": "^1.4.0"
-            }
-        },
-        "node_modules/should-format": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/should-format/-/should-format-3.0.3.tgz",
-            "integrity": "sha512-hZ58adtulAk0gKtua7QxevgUaXTTXxIi8t41L3zo9AHvjXO1/7sdLECuHeIN2SRtYXpNkmhoUP2pdeWgricQ+Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "should-type": "^1.3.0",
-                "should-type-adaptors": "^1.0.1"
-            }
-        },
-        "node_modules/should-type": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/should-type/-/should-type-1.4.0.tgz",
-            "integrity": "sha512-MdAsTu3n25yDbIe1NeN69G4n6mUnJGtSJHygX3+oN0ZbO3DTiATnf7XnYJdGT42JCXurTb1JI0qOBR65shvhPQ==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/should-type-adaptors": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz",
-            "integrity": "sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "should-type": "^1.3.0",
-                "should-util": "^1.0.0"
-            }
-        },
-        "node_modules/should-util": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/should-util/-/should-util-1.0.1.tgz",
-            "integrity": "sha512-oXF8tfxx5cDk8r2kYqlkUJzZpDBqVY/II2WhvU0n9Y3XYvAYRmeaf1PvvIvTgPnv4KJ+ES5M0PyDq5Jp+Ygy2g==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/side-channel": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
@@ -12403,6 +12266,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
             "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -12627,6 +12491,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
             "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+            "dev": true,
             "engines": {
                 "node": ">=10.0.0"
             }
@@ -12955,34 +12820,6 @@
                 "express": ">=4.0.0 || >=5.0.0-beta"
             }
         },
-        "node_modules/swagger2openapi": {
-            "version": "7.0.8",
-            "resolved": "https://registry.npmjs.org/swagger2openapi/-/swagger2openapi-7.0.8.tgz",
-            "integrity": "sha512-upi/0ZGkYgEcLeGieoz8gT74oWHA0E7JivX7aN9mAf+Tc7BQoRBvnIGHoPDw+f9TXTW4s6kGYCZJtauP6OYp7g==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "call-me-maybe": "^1.0.1",
-                "node-fetch": "^2.6.1",
-                "node-fetch-h2": "^2.3.0",
-                "node-readfiles": "^0.2.0",
-                "oas-kit-common": "^1.0.8",
-                "oas-resolver": "^2.5.6",
-                "oas-schema-walker": "^1.1.5",
-                "oas-validator": "^5.0.8",
-                "reftools": "^1.1.9",
-                "yaml": "^1.10.0",
-                "yargs": "^17.0.1"
-            },
-            "bin": {
-                "boast": "boast.js",
-                "oas-validate": "oas-validate.js",
-                "swagger2openapi": "swagger2openapi.js"
-            },
-            "funding": {
-                "url": "https://github.com/Mermade/oas-kit?sponsor=1"
-            }
-        },
         "node_modules/tar-fs": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
@@ -13173,6 +13010,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
             "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "is-number": "^7.0.0"
@@ -13581,23 +13419,6 @@
                 "node": ">=14.17"
             }
         },
-        "node_modules/typescript-ioc": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/typescript-ioc/-/typescript-ioc-3.2.2.tgz",
-            "integrity": "sha512-NI09BFj213x8vqOboOgrQt94MdNfKuXi68pnp4obT9a3uRk5cVjTPagLwkvZJXpSN4iV3sbSGhlQgY2uHEBhoA==",
-            "license": "MIT",
-            "dependencies": {
-                "lodash.get": "^4.4.2",
-                "lodash.set": "^4.3.2",
-                "reflect-metadata": "^0.1.13"
-            }
-        },
-        "node_modules/typescript-ioc/node_modules/reflect-metadata": {
-            "version": "0.1.14",
-            "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.14.tgz",
-            "integrity": "sha512-ZhYeb6nRaXCfhnndflDK8qI6ZQ/YcWZCISRAWICW9XYqMUwjZM9Z0DveWX/ABN01oxSHwVxKQmxeYZSsm0jh5A==",
-            "license": "Apache-2.0"
-        },
         "node_modules/typescript-logging": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/typescript-logging/-/typescript-logging-2.2.0.tgz",
@@ -13611,168 +13432,6 @@
             "license": "Apache-2.0",
             "peerDependencies": {
                 "typescript-logging": "~2.2.0"
-            }
-        },
-        "node_modules/typescript-rest": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/typescript-rest/-/typescript-rest-3.0.4.tgz",
-            "integrity": "sha512-sYM9AZoniflWJBffzke82uD1IW5cR1xYvO7L6fd+gVdhvrqT9SozaDKNLhtRcUiKk7gCWz0hPYTsMfE5tYC+5g==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/body-parser": "1.19.0",
-                "@types/cookie-parser": "^1.4.2",
-                "@types/express": "^4.17.12",
-                "@types/multer": "1.4.5",
-                "@types/passport": "^1.0.6",
-                "@types/serve-static": "^1.13.9",
-                "body-parser": "^1.19.0",
-                "cookie-parser": "^1.4.5",
-                "express": "^4.17.1",
-                "fs-extra": "^10.0.0",
-                "lodash": "^4.17.21",
-                "multer": "^1.4.2",
-                "passport": "^0.4.1",
-                "path": "^0.12.7",
-                "reflect-metadata": "^0.1.13",
-                "require-glob": "^4.0.0",
-                "swagger-ui-express": "^4.1.6",
-                "yamljs": "^0.3.0"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "node_modules/typescript-rest-ioc": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/typescript-rest-ioc/-/typescript-rest-ioc-1.0.1.tgz",
-            "integrity": "sha512-HAG4jqy2Itr1fLrQVPtbMzAHdOWqG/GSFWF6tDgu5ZV40iT+d7tERTpvUgAfRmjBIVeL3yfck5Ocl7P8r6ePxw==",
-            "license": "MIT",
-            "dependencies": {
-                "lodash": "^4.17.15"
-            },
-            "peerDependencies": {
-                "typescript-ioc": "^3.0.2",
-                "typescript-rest": "^3.0.4"
-            }
-        },
-        "node_modules/typescript-rest-swagger": {
-            "version": "1.4.0",
-            "resolved": "git+ssh://git@github.com/nmshd/typescript-rest-swagger.git#7f203ae61cec5fb92c0a1b2cfa7d1bd2d1535aa8",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@apidevtools/swagger-parser": "^10.1.0",
-                "argparse": "^2.0.1",
-                "debug": "^4.3.4",
-                "fs-extra-promise": "^1.0.1",
-                "glob": "^10.3.10",
-                "lodash": "^4.17.21",
-                "merge": "^2.1.1",
-                "minimatch": "^9.0.3",
-                "mkdirp": "^3.0.1",
-                "openapi-types": "^12.1.3",
-                "path": "^0.12.7",
-                "swagger2openapi": "^7.0.8",
-                "ts-morph": "^23.0.0",
-                "typescript": "^5.5.3",
-                "typescript-rest": "^3.0.4",
-                "yamljs": "^0.3.0"
-            },
-            "bin": {
-                "swaggerGen": "dist/cli.js"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "node_modules/typescript-rest-swagger/node_modules/argparse": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-            "dev": true,
-            "license": "Python-2.0"
-        },
-        "node_modules/typescript-rest-swagger/node_modules/mkdirp": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
-            "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "mkdirp": "dist/cjs/src/bin.js"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/typescript-rest/node_modules/@types/body-parser": {
-            "version": "1.19.0",
-            "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.0.tgz",
-            "integrity": "sha512-W98JrE0j2K78swW4ukqMleo8R7h/pFETjM2DQ90MF6XK2i4LO4W3gQ71Lt4w3bfm2EvVSyWHplECvB5sK22yFQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/connect": "*",
-                "@types/node": "*"
-            }
-        },
-        "node_modules/typescript-rest/node_modules/@types/express": {
-            "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
-            "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
-            "dependencies": {
-                "@types/body-parser": "*",
-                "@types/express-serve-static-core": "^4.17.33",
-                "@types/qs": "*",
-                "@types/serve-static": "*"
-            }
-        },
-        "node_modules/typescript-rest/node_modules/@types/express-serve-static-core": {
-            "version": "4.19.6",
-            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz",
-            "integrity": "sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==",
-            "dependencies": {
-                "@types/node": "*",
-                "@types/qs": "*",
-                "@types/range-parser": "*",
-                "@types/send": "*"
-            }
-        },
-        "node_modules/typescript-rest/node_modules/fs-extra": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-            "license": "MIT",
-            "dependencies": {
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/typescript-rest/node_modules/reflect-metadata": {
-            "version": "0.1.14",
-            "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.14.tgz",
-            "integrity": "sha512-ZhYeb6nRaXCfhnndflDK8qI6ZQ/YcWZCISRAWICW9XYqMUwjZM9Z0DveWX/ABN01oxSHwVxKQmxeYZSsm0jh5A==",
-            "license": "Apache-2.0"
-        },
-        "node_modules/typescript-rest/node_modules/swagger-ui-express": {
-            "version": "4.6.3",
-            "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.6.3.tgz",
-            "integrity": "sha512-CDje4PndhTD2HkgyKH3pab+LKspDeB/NhPN2OF1j+piYIamQqBYwAXWESOT1Yju2xFg51bRW9sUng2WxDjzArw==",
-            "license": "MIT",
-            "dependencies": {
-                "swagger-ui-dist": ">=4.11.0"
-            },
-            "engines": {
-                "node": ">= v0.10.32"
-            },
-            "peerDependencies": {
-                "express": ">=4.0.0 || >=5.0.0-beta"
             }
         },
         "node_modules/unbox-primitive": {
@@ -13808,6 +13467,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
             "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 10.0.0"
@@ -13878,15 +13538,6 @@
                 "requires-port": "^1.0.0"
             }
         },
-        "node_modules/util": {
-            "version": "0.10.4",
-            "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
-            "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
-            "license": "MIT",
-            "dependencies": {
-                "inherits": "2.0.3"
-            }
-        },
         "node_modules/util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -13899,12 +13550,6 @@
             "integrity": "sha512-mLs5zAK+ctllYBj+iAQvlDCwoxU/WDOUaJkcFudeiAX6OajC6BKXJUa9a+tbtkC11dz2Ufb7h0lyvIOVn4LADA==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/util/node_modules/inherits": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
-            "license": "ISC"
         },
         "node_modules/utils-merge": {
             "version": "1.0.1",
@@ -14281,6 +13926,7 @@
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
             "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.4"
@@ -14301,16 +13947,6 @@
             "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
             "dev": true,
             "license": "ISC"
-        },
-        "node_modules/yaml": {
-            "version": "1.10.2",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-            "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">= 6"
-            }
         },
         "node_modules/yamljs": {
             "version": "0.3.0",
@@ -14443,7 +14079,7 @@
             "name": "@nmshd/connector-sdk",
             "license": "MIT",
             "dependencies": {
-                "@nmshd/content": "6.3.0",
+                "@nmshd/content": "6.3.1",
                 "axios": "^1.7.7",
                 "form-data": "^4.0.1",
                 "qs": "^6.13.0"
@@ -14452,31 +14088,6 @@
                 "@types/form-data": "^2.5.0",
                 "@types/qs": "^6.9.16",
                 "ts-json-schema-generator": "^2.3.0"
-            }
-        },
-        "packages/sdk/node_modules/@nmshd/content": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/@nmshd/content/-/content-6.2.0.tgz",
-            "integrity": "sha512-CDwsFv4Do56+KTq7exuBkuuGu8JN8gmLBYvzIz/WfGDRGFkwuuQpHkC2ORT995uq6jTq8OY+7QR4gZW4uRv1wg==",
-            "license": "MIT",
-            "dependencies": {
-                "@js-soft/ts-serval": "2.0.11",
-                "@nmshd/core-types": "6.2.0",
-                "@nmshd/iql": "^1.0.2",
-                "luxon": "^3.5.0",
-                "ts-simple-nameof": "^1.3.1"
-            }
-        },
-        "packages/sdk/node_modules/@nmshd/core-types": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/@nmshd/core-types/-/core-types-6.2.0.tgz",
-            "integrity": "sha512-VoJ0Qz8G8If9e89vx6hT1ApnDpbYMWgGpuOVq5+Upp3p2aCf6a/E2ySi8IGTxQ03FrBMNl1dgdGb8eurh+isww==",
-            "license": "MIT",
-            "dependencies": {
-                "@js-soft/logging-abstractions": "^1.0.1",
-                "@js-soft/ts-serval": "2.0.11",
-                "json-stringify-safe": "^5.0.1",
-                "luxon": "^3.5.0"
             }
         }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
                 "@js-soft/ts-utils": "^2.3.3",
                 "@nmshd/runtime": "6.3.1",
                 "@nmshd/typescript-ioc": "^3.2.4",
+                "@nmshd/typescript-rest": "^3.0.5",
                 "agentkeepalive": "4.5.0",
                 "amqplib": "^0.10.4",
                 "axios": "^1.7.7",
@@ -2162,7 +2163,6 @@
             "version": "3.0.5",
             "resolved": "https://registry.npmjs.org/@nmshd/typescript-rest/-/typescript-rest-3.0.5.tgz",
             "integrity": "sha512-XhXwB17qT9fz8PJqUNEM/NZ0hHuFSiWEZeFnnmy0MQYcj5lAEfDOTn6y547pCwrHr6eFboB5JzfUpY7NkOa8gg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/body-parser": "1.19.5",
@@ -2223,7 +2223,6 @@
             "version": "1.4.12",
             "resolved": "https://registry.npmjs.org/@types/multer/-/multer-1.4.12.tgz",
             "integrity": "sha512-pQ2hoqvXiJt2FP9WQVLPRO+AmiIm/ZYkavPlIQnx282u4ZrVdztx0pkh3jjpQt0Kz+YI0YhSG264y08UJKoUQg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/express": "*"
@@ -2233,7 +2232,6 @@
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
             "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@nodelib/fs.stat": "2.0.5",
@@ -2247,7 +2245,6 @@
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
             "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 8"
@@ -2257,7 +2254,6 @@
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
             "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@nodelib/fs.scandir": "2.1.5",
@@ -3034,7 +3030,6 @@
             "version": "1.19.5",
             "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
             "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/connect": "*",
@@ -3061,7 +3056,6 @@
             "version": "3.4.38",
             "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
             "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/node": "*"
@@ -3071,7 +3065,6 @@
             "version": "1.4.7",
             "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.7.tgz",
             "integrity": "sha512-Fvuyi354Z+uayxzIGCwYTayFKocfV7TuDYZClCdIP9ckhvAu/ixDtCB6qx2TT0FKjPLf1f3P/J1rgf6lPs64mw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/express": "*"
@@ -3098,7 +3091,6 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.0.tgz",
             "integrity": "sha512-DvZriSMehGHL1ZNLzi6MidnsDhUZM/x2pRdDIKdwbUNqqwHxMlRdkxtn6/EPKyqKpHqTl/4nRZsRNLpZxZRpPQ==",
-            "dev": true,
             "dependencies": {
                 "@types/body-parser": "*",
                 "@types/express-serve-static-core": "^5.0.0",
@@ -3110,7 +3102,6 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.0.tgz",
             "integrity": "sha512-AbXMTZGt40T+KON9/Fdxx0B2WK5hsgxcfXJLr5bFpZ7b4JCex2WyQPTEKdXqfHiY5nKKBScZ7yCoO6Pvgxfvnw==",
-            "dev": true,
             "dependencies": {
                 "@types/node": "*",
                 "@types/qs": "*",
@@ -3143,7 +3134,6 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
             "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/istanbul-lib-coverage": {
@@ -3262,7 +3252,6 @@
             "version": "1.3.5",
             "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
             "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/nconf": {
@@ -3295,7 +3284,6 @@
             "version": "6.9.16",
             "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.16.tgz",
             "integrity": "sha512-7i+zxXdPD0T4cKDuxCUXJ4wHcsJLwENa6Z3dCu8cfCK743OGy5Nu1RmAGqDPsoTDINVEcdXKRvR/zre+P2Ku1A==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/ramda": {
@@ -3309,8 +3297,7 @@
         "node_modules/@types/range-parser": {
             "version": "1.2.7",
             "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
-            "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-            "dev": true
+            "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="
         },
         "node_modules/@types/readable-stream": {
             "version": "4.0.15",
@@ -3352,7 +3339,6 @@
             "version": "0.17.4",
             "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
             "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/mime": "^1",
@@ -3363,7 +3349,6 @@
             "version": "1.15.7",
             "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.7.tgz",
             "integrity": "sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/http-errors": "*",
@@ -3895,7 +3880,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
             "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/arg": {
@@ -3951,7 +3935,6 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
             "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -4404,7 +4387,6 @@
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
             "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "fill-range": "^7.1.1"
@@ -4524,7 +4506,6 @@
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
             "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-            "dev": true,
             "dependencies": {
                 "streamsearch": "^1.1.0"
             },
@@ -4605,7 +4586,6 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
             "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -5036,7 +5016,6 @@
             "version": "1.4.7",
             "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
             "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "cookie": "0.7.2",
@@ -5561,7 +5540,6 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
             "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "path-type": "^4.0.0"
@@ -6444,7 +6422,6 @@
             "version": "3.3.2",
             "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
             "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@nodelib/fs.stat": "^2.0.2",
@@ -6461,7 +6438,6 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
             "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "is-glob": "^4.0.1"
@@ -6513,7 +6489,6 @@
             "version": "1.17.1",
             "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
             "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "reusify": "^1.0.4"
@@ -6569,7 +6544,6 @@
             "version": "7.1.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
             "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "to-regex-range": "^5.0.1"
@@ -6745,7 +6719,6 @@
             "version": "11.2.0",
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
             "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "graceful-fs": "^4.2.0",
@@ -7046,7 +7019,6 @@
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
             "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "is-glob": "^4.0.3"
@@ -7104,7 +7076,6 @@
             "version": "11.1.0",
             "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
             "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "array-union": "^2.1.0",
@@ -7443,7 +7414,6 @@
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
             "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 4"
@@ -7685,7 +7655,6 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
             "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -7714,7 +7683,6 @@
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
             "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "is-extglob": "^2.1.1"
@@ -7740,7 +7708,6 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.12.0"
@@ -8940,7 +8907,6 @@
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
             "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "universalify": "^2.0.0"
@@ -9427,7 +9393,6 @@
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
             "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 8"
@@ -9446,7 +9411,6 @@
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
             "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "braces": "^3.0.3",
@@ -9570,7 +9534,6 @@
             "version": "0.5.6",
             "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
             "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "minimist": "^1.2.6"
@@ -9745,7 +9708,6 @@
             "version": "1.4.5-lts.1",
             "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.5-lts.1.tgz",
             "integrity": "sha512-ywPWvcDMeH+z9gQq5qYHCCy+ethsk4goepZ45GLD63fOu0YcNecQxi64nDs3qluZB+murG3/D4dJ7+dGctcCQQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "append-field": "^1.0.0",
@@ -9764,7 +9726,6 @@
             "version": "1.6.2",
             "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
             "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-            "dev": true,
             "engines": [
                 "node >= 0.8"
             ],
@@ -9780,14 +9741,12 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
             "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/multer/node_modules/readable-stream": {
             "version": "2.3.8",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
             "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "core-util-is": "~1.0.0",
@@ -9803,7 +9762,6 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "safe-buffer": "~5.1.0"
@@ -10773,7 +10731,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
             "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -10790,7 +10747,6 @@
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
             "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8.6"
@@ -11316,7 +11272,6 @@
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
             "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -11707,7 +11662,6 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/require-glob/-/require-glob-4.1.0.tgz",
             "integrity": "sha512-c66YRk0kDUUz9t+/nEG11dnVh6nLppztiE/TLBerRlAGd75AuCLXHQ6xauOPgZaw9T+6wfG8u8ibfMD9GwmDYw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "glob-parent": "^6.0.0",
@@ -11722,7 +11676,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-2.0.0.tgz",
             "integrity": "sha512-uo0Z9JJeWzv8BG+tRcapBKNJ0dro9cLyczGzulS6EfeyAdeC9sbojtW6XwvYxJkEne9En+J2XEl4zyglVeIwFg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "callsites": "^3.1.0"
@@ -11831,7 +11784,6 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
             "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "iojs": ">=1.0.0",
@@ -11911,7 +11863,6 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
             "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -12266,7 +12217,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
             "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -12491,7 +12441,6 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
             "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-            "dev": true,
             "engines": {
                 "node": ">=10.0.0"
             }
@@ -13010,7 +12959,6 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
             "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "is-number": "^7.0.0"
@@ -13467,7 +13415,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
             "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 10.0.0"
@@ -13926,7 +13873,6 @@
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
             "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.4"

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
         "@js-soft/ts-utils": "^2.3.3",
         "@nmshd/runtime": "6.3.1",
         "@nmshd/typescript-ioc": "^3.2.4",
+        "@nmshd/typescript-rest": "^3.0.5",
         "agentkeepalive": "4.5.0",
         "amqplib": "^0.10.4",
         "axios": "^1.7.7",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,8 @@
         "@js-soft/docdb-access-mongo": "1.1.9",
         "@js-soft/node-logger": "1.2.0",
         "@js-soft/ts-utils": "^2.3.3",
-        "@nmshd/runtime": "6.3.0",
+        "@nmshd/runtime": "6.3.1",
+        "@nmshd/typescript-ioc": "^3.2.4",
         "agentkeepalive": "4.5.0",
         "amqplib": "^0.10.4",
         "axios": "^1.7.7",
@@ -97,16 +98,12 @@
         "json-stringify-safe": "5.0.1",
         "jsonschema": "1.4.1",
         "mqtt": "^5.10.1",
-        "multer": "^1.4.5-lts.1",
         "nconf": "0.12.1",
         "on-headers": "1.0.2",
         "rapidoc": "9.3.8",
         "redis": "^4.7.0",
         "reflect-metadata": "0.2.2",
         "swagger-ui-express": "5.0.1",
-        "typescript-ioc": "3.2.2",
-        "typescript-rest": "3.0.4",
-        "typescript-rest-ioc": "1.0.1",
         "yamljs": "0.3.0"
     },
     "devDependencies": {
@@ -114,8 +111,9 @@
         "@js-soft/eslint-config-ts": "1.6.12",
         "@js-soft/license-check": "1.0.9",
         "@nmshd/connector-sdk": "*",
-        "@nmshd/content": "6.3.0",
-        "@nmshd/core-types": "6.3.0",
+        "@nmshd/content": "6.3.1",
+        "@nmshd/core-types": "6.3.1",
+        "@nmshd/typescript-rest-swagger": "^1.4.1",
         "@types/amqplib": "^0.10.5",
         "@types/compression": "^1.7.5",
         "@types/cors": "^2.8.17",
@@ -144,12 +142,6 @@
         "prettier": "^3.3.3",
         "ts-jest": "^29.2.5",
         "ts-node": "^10.9.2",
-        "typescript": "^5.6.3",
-        "typescript-rest-swagger": "github:nmshd/typescript-rest-swagger#1.4.0"
-    },
-    "overrides": {
-        "typescript-rest": {
-            "multer": "$multer"
-        }
+        "typescript": "^5.6.3"
     }
 }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -30,7 +30,7 @@
         "build:schemas:watch": "npx nodemon -e ts -w 'src/types' --exec 'npm run build:schemas'"
     },
     "dependencies": {
-        "@nmshd/content": "6.3.0",
+        "@nmshd/content": "6.3.1",
         "axios": "^1.7.7",
         "form-data": "^4.0.1",
         "qs": "^6.13.0"

--- a/src/infrastructure/httpServer/middlewares/genericErrorHandler.ts
+++ b/src/infrastructure/httpServer/middlewares/genericErrorHandler.ts
@@ -1,9 +1,9 @@
 import { ApplicationError } from "@js-soft/ts-utils";
 import { RuntimeErrors } from "@nmshd/runtime";
 import { RequestError, TransportCoreErrors } from "@nmshd/transport";
+import { Errors } from "@nmshd/typescript-rest";
 import express from "express";
 import stringify from "json-stringify-safe";
-import { Errors } from "typescript-rest";
 import { ConnectorMode } from "../../../ConnectorMode";
 import { ConnectorLoggerFactory } from "../../../logging/ConnectorLoggerFactory";
 import { Envelope, HttpError, HttpErrors } from "../common";

--- a/src/modules/coreHttpApi/common/BaseController.ts
+++ b/src/modules/coreHttpApi/common/BaseController.ts
@@ -1,6 +1,6 @@
 import { Result } from "@js-soft/ts-utils";
+import { Return } from "@nmshd/typescript-rest";
 import express from "express";
-import { Return } from "typescript-rest";
 import { Envelope } from "../../../infrastructure";
 
 export abstract class BaseController {

--- a/src/modules/coreHttpApi/controllers/AccountController.ts
+++ b/src/modules/coreHttpApi/controllers/AccountController.ts
@@ -1,6 +1,6 @@
 import { TransportServices } from "@nmshd/runtime";
-import { Inject } from "typescript-ioc";
-import { Accept, GET, Path, POST } from "typescript-rest";
+import { Inject } from "@nmshd/typescript-ioc";
+import { Accept, GET, Path, POST } from "@nmshd/typescript-rest";
 import { Envelope } from "../../../infrastructure";
 import { BaseController } from "../common/BaseController";
 

--- a/src/modules/coreHttpApi/controllers/AttributesController.ts
+++ b/src/modules/coreHttpApi/controllers/AttributesController.ts
@@ -1,6 +1,6 @@
 import { ConsumptionServices, RuntimeErrors, TransportServices } from "@nmshd/runtime";
-import { Inject } from "typescript-ioc";
-import { Accept, Context, DELETE, GET, POST, Path, PathParam, QueryParam, Return, ServiceContext } from "typescript-rest";
+import { Inject } from "@nmshd/typescript-ioc";
+import { Accept, Context, DELETE, GET, POST, Path, PathParam, QueryParam, Return, ServiceContext } from "@nmshd/typescript-rest";
 import { Envelope } from "../../../infrastructure";
 import { BaseController } from "../common/BaseController";
 

--- a/src/modules/coreHttpApi/controllers/ChallengesController.ts
+++ b/src/modules/coreHttpApi/controllers/ChallengesController.ts
@@ -1,6 +1,6 @@
 import { TransportServices } from "@nmshd/runtime";
-import { Inject } from "typescript-ioc";
-import { Accept, Path, POST, Return } from "typescript-rest";
+import { Inject } from "@nmshd/typescript-ioc";
+import { Accept, Path, POST, Return } from "@nmshd/typescript-rest";
 import { Envelope } from "../../../infrastructure";
 import { BaseController } from "../common/BaseController";
 

--- a/src/modules/coreHttpApi/controllers/FilesController.ts
+++ b/src/modules/coreHttpApi/controllers/FilesController.ts
@@ -1,8 +1,8 @@
 import { OwnerRestriction, TransportServices } from "@nmshd/runtime";
 import { Reference } from "@nmshd/transport";
+import { Inject } from "@nmshd/typescript-ioc";
+import { Accept, Context, ContextAccept, ContextResponse, Errors, FileParam, FormParam, GET, POST, Path, PathParam, Return, ServiceContext } from "@nmshd/typescript-rest";
 import express from "express";
-import { Inject } from "typescript-ioc";
-import { Accept, Context, ContextAccept, ContextResponse, Errors, FileParam, FormParam, GET, POST, Path, PathParam, Return, ServiceContext } from "typescript-rest";
 import { Envelope } from "../../../infrastructure";
 import { BaseController, Mimetype } from "../common/BaseController";
 

--- a/src/modules/coreHttpApi/controllers/IncomingRequestsController.ts
+++ b/src/modules/coreHttpApi/controllers/IncomingRequestsController.ts
@@ -1,6 +1,6 @@
 import { ConsumptionServices } from "@nmshd/runtime";
-import { Inject } from "typescript-ioc";
-import { Accept, Context, GET, Path, PathParam, PUT, ServiceContext } from "typescript-rest";
+import { Inject } from "@nmshd/typescript-ioc";
+import { Accept, Context, GET, Path, PathParam, PUT, ServiceContext } from "@nmshd/typescript-rest";
 import { Envelope } from "../../../infrastructure";
 import { BaseController } from "../common/BaseController";
 

--- a/src/modules/coreHttpApi/controllers/MessagesController.ts
+++ b/src/modules/coreHttpApi/controllers/MessagesController.ts
@@ -1,7 +1,7 @@
 import { TransportServices } from "@nmshd/runtime";
+import { Inject } from "@nmshd/typescript-ioc";
+import { Accept, Context, ContextResponse, GET, Path, PathParam, POST, Return, ServiceContext } from "@nmshd/typescript-rest";
 import express from "express";
-import { Inject } from "typescript-ioc";
-import { Accept, Context, ContextResponse, GET, Path, PathParam, POST, Return, ServiceContext } from "typescript-rest";
 import { Envelope } from "../../../infrastructure";
 import { BaseController, Mimetype } from "../common/BaseController";
 

--- a/src/modules/coreHttpApi/controllers/OutgoingRequestsController.ts
+++ b/src/modules/coreHttpApi/controllers/OutgoingRequestsController.ts
@@ -1,6 +1,6 @@
 import { ConsumptionServices } from "@nmshd/runtime";
-import { Inject } from "typescript-ioc";
-import { Accept, Context, GET, Path, PathParam, POST, Return, ServiceContext } from "typescript-rest";
+import { Inject } from "@nmshd/typescript-ioc";
+import { Accept, Context, GET, Path, PathParam, POST, Return, ServiceContext } from "@nmshd/typescript-rest";
 import { Envelope } from "../../../infrastructure";
 import { BaseController } from "../common/BaseController";
 

--- a/src/modules/coreHttpApi/controllers/RelationshipTemplatesController.ts
+++ b/src/modules/coreHttpApi/controllers/RelationshipTemplatesController.ts
@@ -1,7 +1,7 @@
 import { OwnerRestriction, TransportServices } from "@nmshd/runtime";
+import { Inject } from "@nmshd/typescript-ioc";
+import { Accept, Context, ContextAccept, ContextResponse, Errors, GET, POST, Path, PathParam, Return, ServiceContext } from "@nmshd/typescript-rest";
 import express from "express";
-import { Inject } from "typescript-ioc";
-import { Accept, Context, ContextAccept, ContextResponse, Errors, GET, POST, Path, PathParam, Return, ServiceContext } from "typescript-rest";
 import { Envelope } from "../../../infrastructure";
 import { BaseController, Mimetype } from "../common/BaseController";
 

--- a/src/modules/coreHttpApi/controllers/RelationshipsController.ts
+++ b/src/modules/coreHttpApi/controllers/RelationshipsController.ts
@@ -1,6 +1,6 @@
 import { TransportServices } from "@nmshd/runtime";
-import { Inject } from "typescript-ioc";
-import { Accept, Context, DELETE, GET, Path, PathParam, POST, PUT, Return, ServiceContext } from "typescript-rest";
+import { Inject } from "@nmshd/typescript-ioc";
+import { Accept, Context, DELETE, GET, Path, PathParam, POST, PUT, Return, ServiceContext } from "@nmshd/typescript-rest";
 import { Envelope } from "../../../infrastructure";
 import { BaseController } from "../common/BaseController";
 

--- a/src/modules/coreHttpApi/controllers/TokensController.ts
+++ b/src/modules/coreHttpApi/controllers/TokensController.ts
@@ -1,7 +1,7 @@
 import { OwnerRestriction, TransportServices } from "@nmshd/runtime";
+import { Inject } from "@nmshd/typescript-ioc";
+import { Accept, Context, ContextAccept, ContextResponse, Errors, GET, Path, PathParam, POST, Return, ServiceContext } from "@nmshd/typescript-rest";
 import express from "express";
-import { Inject } from "typescript-ioc";
-import { Accept, Context, ContextAccept, ContextResponse, Errors, GET, Path, PathParam, POST, Return, ServiceContext } from "typescript-rest";
 import { Envelope } from "../../../infrastructure";
 import { BaseController, Mimetype } from "../common/BaseController";
 

--- a/test/spec.test.ts
+++ b/test/spec.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable jest/no-conditional-in-test */
 import swaggerParser from "@apidevtools/swagger-parser";
+import { MetadataGenerator, SpecGenerator, Swagger } from "@nmshd/typescript-rest-swagger";
 import { OpenAPIV3 } from "openapi-types";
-import { MetadataGenerator, SpecGenerator, Swagger } from "typescript-rest-swagger";
 import yamljs from "yamljs";
 
 describe("test openapi spec against routes", () => {


### PR DESCRIPTION
# Readiness checklist

-   [ ] I added/updated tests.
-   [x] I ensured that the PR title is good enough for the changelog.
-   [x] I labeled the PR.

# Description

- [typescript-ioc](https://github.com/nmshd/typescript-ioc) is forked and it's dependencies are updated, the lib is published under `@nmshd/typescript-ioc`
- [typescript-rest](https://github.com/nmshd/typescript-rest) is also forked and it's dependencies are updated, the lib is published under `@nmshd/typescript-rest`
- typescript-rest-ioc was not be updated and the code (only one file) was moved inside the connector