### PR TITLE
Re-add deprecated function deleteThirdPartyOwnedRelationshipAttributeAndNotifyPeer

### DIFF
--- a/packages/sdk/src/endpoints/AttributesEndpoint.ts
+++ b/packages/sdk/src/endpoints/AttributesEndpoint.ts
@@ -89,6 +89,15 @@ export class AttributesEndpoint extends Endpoint {
         return await this.delete(`/api/v2/Attributes/ThirdParty/${attributeId}`);
     }
 
+    /**
+     * @deprecated use deleteThirdPartyRelationshipAttributeAndNotifyPeer instead
+     */
+    public async deleteThirdPartyOwnedRelationshipAttributeAndNotifyPeer(
+        attributeId: string
+    ): Promise<ConnectorHttpResponse<DeleteThirdPartyRelationshipAttributeAndNotifyPeerResponse>> {
+        return await this.deleteThirdPartyRelationshipAttributeAndNotifyPeer(attributeId);
+    }
+
     public async executeIdentityAttributeQuery(request: ExecuteIdentityAttributeQueryRequest): Promise<ConnectorHttpResponse<ConnectorAttributes>> {
         return await this.post("/api/v2/Attributes/ExecuteIdentityAttributeQuery", request, 200);
     }


### PR DESCRIPTION
For backwards compatibility

# Readiness checklist

-   [ ] I added/updated tests.
-   [x] I ensured that the PR title is good enough for the changelog.
-   [x] I labeled the PR.
