### PR TITLE
`@type` is displayed as required in `onNewRelationship`

### DIFF
--- a/src/modules/coreHttpApi/openapi.yml
+++ b/src/modules/coreHttpApi/openapi.yml
@@ -5069,7 +5069,6 @@ components:
               - $ref: "#/components/schemas/RequestItem"
               - $ref: "#/components/schemas/RequestItemGroup"
       required:
-        - "@type"
         - items
 
     RequestResponseContentItem:


### PR DESCRIPTION
# Readiness checklist

-   [ ] I added/updated tests.
-   [x] I ensured that the PR title is good enough for the changelog.
-   [x] I labeled the PR.

# Description

Fixes nmshd/feedback#29

The openapi declaration was incorrect as ts-serval omits `@type`s that can only have one value (like in this case `"Request"`).