### PR TITLE
Some objects in the OpenAPI spec are incorrect

### DIFF
--- a/src/modules/coreHttpApi/openapi.yml
+++ b/src/modules/coreHttpApi/openapi.yml
@@ -5614,6 +5614,20 @@ components:
             - $ref: "#/components/schemas/Address"
           nullable: false
           description: The address of the peer identity.
+        peerIdentity:
+          type: object
+          additionalProperties: false
+          properties:
+            address:
+              allOf:
+                - $ref: "#/components/schemas/Address"
+              nullable: false
+            publicKey:
+              type: string
+              nullable: false
+          required:
+            - address
+            - publicKey
         peerDeletionInfo:
           type: object
           additionalProperties: false

--- a/src/modules/coreHttpApi/openapi.yml
+++ b/src/modules/coreHttpApi/openapi.yml
@@ -5113,7 +5113,6 @@ components:
               - $ref: "#/components/schemas/RequestResponseContentItem"
               - $ref: "#/components/schemas/RequestResponseContentItemGroup"
       required:
-        - "@type"
         - result
         - requestId
         - items

--- a/src/modules/coreHttpApi/openapi.yml
+++ b/src/modules/coreHttpApi/openapi.yml
@@ -5659,6 +5659,7 @@ components:
         - template
         - status
         - peer
+        - peerIdentity
         - creationContent
         - auditLog
 


### PR DESCRIPTION
# Readiness checklist

-   [ ] I added/updated tests.
-   [x] I ensured that the PR title is good enough for the changelog.
-   [x] I labeled the PR.

# Description

Fixes nmshd/feedback#29

Fixed issues:
- `@type` is displayed as required in `RequestResponseContent`
- `peerIdentity` is missing in `Relationship`