### PR TITLE
the error message for an invalid baseUrl is misleading

### DIFF
--- a/src/CreateConnectorConfig.ts
+++ b/src/CreateConnectorConfig.ts
@@ -96,4 +96,10 @@ function validateConnectorConfig(connectorConfig: ConnectorRuntimeConfig): void 
         }
         throw new Error(errorMessage);
     }
+
+    if (!connectorConfig.transportLibrary.baseUrl.startsWith("http://") || !connectorConfig.transportLibrary.baseUrl.startsWith("https://")) {
+        // eslint-disable-next-line no-console
+        console.error("The 'transportLibrary.baseUrl' must either start with 'http://' or 'https://'.");
+        process.exit(1);
+    }
 }


### PR DESCRIPTION
# Readiness checklist

-   [ ] I added/updated tests.
-   [ ] I ensured that the PR title is good enough for the changelog.
-   [ ] I labeled the PR.
-   [ ] I self-reviewed the PR.

# Description

Instead of 

```
connector-1  | start
connector-1  | 
connector-1  | start the connector
connector-1  | 
connector-1  | Options:
connector-1  |       --version  Show version number                                   [boolean]
connector-1  |   -c, --config   Path to the custom configuration file
connector-1  |                  Can also be set via the CUSTOM_CONFIG_LOCATION env variable
connector-1  |                                                                         [string]
connector-1  |   -h, --help     Show help                                             [boolean]
connector-1  | 
connector-1  | TypeError: Invalid URL
connector-1  |     at new URL (node:internal/url:818:25)
connector-1  |     at dispatchHttpRequest (/usr/app/node_modules/axios/dist/node/axios.cjs:2777:20)
connector-1  |     at /usr/app/node_modules/axios/dist/node/axios.cjs:2697:5
connector-1  |     at new Promise (<anonymous>)
connector-1  |     at wrapAsync (/usr/app/node_modules/axios/dist/node/axios.cjs:2677:10)
connector-1  |     at http (/usr/app/node_modules/axios/dist/node/axios.cjs:2715:10)
connector-1  |     at Axios.dispatchRequest (/usr/app/node_modules/axios/dist/node/axios.cjs:4092:10)
connector-1  |     at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
connector-1  |     at async Axios.request (/usr/app/node_modules/axios/dist/node/axios.cjs:4247:14)
connector-1  |     at async VersionClient.get (/usr/app/node_modules/@nmshd/transport/dist/core/backbone/RESTClient.js:232:30)
connector-1  |     at Axios.request (/usr/app/node_modules/axios/dist/node/axios.cjs:4252:41)
connector-1  |     at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
connector-1  |     at async VersionClient.get (/usr/app/node_modules/@nmshd/transport/dist/core/backbone/RESTClient.js:232:30)
connector-1  |     at async VersionClient.getBackboneVersion (/usr/app/node_modules/@nmshd/transport/dist/modules/backboneCompatibility/backbone/VersionClient.js:7:16)
connector-1  |     at async BackboneCompatibilityController.checkBackboneCompatibility (/usr/app/node_modules/@nmshd/transport/dist/modules/backboneCompatibility/BackboneCompatibilityController.js:13:42)
connector-1  |     at async CheckBackboneCompatibilityUseCase.executeInternal (/usr/app/node_modules/@nmshd/runtime/dist/useCases/anonymous/backboneCompatibility/CheckBackboneCompatibilityUseCase.js:26:24)
connector-1  |     at async CheckBackboneCompatibilityUseCase._executeCallback (/usr/app/node_modules/@nmshd/runtime/dist/useCases/common/UseCase.js:48:20)
connector-1  |     at async CheckBackboneCompatibilityUseCase.execute (/usr/app/node_modules/@nmshd/runtime/dist/useCases/common/UseCase.js:38:16)
connector-1  |     at async BackboneCompatibilityFacade.checkBackboneCompatibility (/usr/app/node_modules/@nmshd/runtime/dist/extensibility/facades/anonymous/BackboneCompatibilityFacade.js:23:16)
connector-1  |     at async ConnectorRuntime.runBackboneCompatibilityCheck (/usr/app/dist/ConnectorRuntime.js:120:37) {
connector-1  |   code: 'error.transport.request.unknown',
connector-1  |   data: undefined,
connector-1  |   method: 'GET',
connector-1  |   path: '/api/v1/Version',
connector-1  |   platformParameters: undefined,
connector-1  |   reason: 'Invalid URL',
connector-1  |   requestId: '',
connector-1  |   status: 500,
connector-1  |   time: '2024-12-18T10:15:04.254Z',
connector-1  |   object: undefined
connector-1  | }
```

we now get this

```
connector-1  | start
connector-1  | 
connector-1  | start the connector
connector-1  | 
connector-1  | Options:
connector-1  |       --version  Show version number                                   [boolean]
connector-1  |   -c, --config   Path to the custom configuration file
connector-1  |                  Can also be set via the CUSTOM_CONFIG_LOCATION env variable
connector-1  |                                                                         [string]
connector-1  |   -h, --help     Show help                                             [boolean]
connector-1  | 
connector-1  | Error: The 'transportLibrary.baseUrl' must either start with 'http://' or 'https://'.
connector-1  |     at validateConnectorConfig (/usr/app/dist/CreateConnectorConfig.js:90:15)
connector-1  |     at createConnectorConfig (/usr/app/dist/CreateConnectorConfig.js:39:5)
connector-1  |     at Object.startConnectorHandler [as handler] (/usr/app/dist/cli/commands/startConnector.js:8:79)
connector-1  |     at /usr/app/node_modules/yargs/build/index.cjs:1:8993
connector-1  |     at j (/usr/app/node_modules/yargs/build/index.cjs:1:4956)
connector-1  |     at _.handleValidationAndGetResult (/usr/app/node_modules/yargs/build/index.cjs:1:8962)
connector-1  |     at _.applyMiddlewareAndGetResult (/usr/app/node_modules/yargs/build/index.cjs:1:9604)
connector-1  |     at _.runCommand (/usr/app/node_modules/yargs/build/index.cjs:1:7231)
connector-1  |     at [runYargsParserAndExecuteCommands] (/usr/app/node_modules/yargs/build/index.cjs:1:58539)
connector-1  |     at te.parse (/usr/app/node_modules/yargs/build/index.cjs:1:40478)
```
