### PR TITLE
Connector does not start in kubernetes

### DIFF
--- a/.dev/Dockerfile.debug
+++ b/.dev/Dockerfile.debug
@@ -2,6 +2,6 @@ FROM node:23.7.0
 WORKDIR /usr/app
 
 # Webserver, Debugger
-EXPOSE 80 9229
+EXPOSE 8080 9229
 
 ENTRYPOINT ["npx", "nodemon", "-e", "js,json,yml", "--watch", "./dist", "--watch", "./config", "--inspect=0.0.0.0:9229", "--nolazy", "./dist/index.js", "start"]

--- a/.dev/compose.prodtest.yml
+++ b/.dev/compose.prodtest.yml
@@ -12,7 +12,7 @@ services:
         COMMIT_HASH: "test"
     container_name: connector
     ports:
-      - "3000:80" # Webserver
+      - "3000:8080" # Webserver
     environment:
       DATABASE_NAME: "prod_connector"
       transportLibrary__baseUrl: "http://consumer-api:8080"

--- a/.dev/compose.yml
+++ b/.dev/compose.yml
@@ -7,7 +7,7 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     ports:
-      - "3000:80" # Webserver
+      - "3000:8080" # Webserver
       - "9229:9229" # Debugger
     environment:
       - CUSTOM_CONFIG_LOCATION=/config.json
@@ -36,7 +36,7 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     ports:
-      - "3001:80" # Webserver
+      - "3001:8080" # Webserver
       - "9231:9229" # Debugger
     environment:
       - CUSTOM_CONFIG_LOCATION=/config.json

--- a/README_dev.md
+++ b/README_dev.md
@@ -34,7 +34,7 @@ After a few seconds you should see the following output:
 ```console
 connector-1  | [2021-01-25T11:27:40.788] [INFO] Transport.Transport - Transport initialized
 ...
-connector-1  | [2021-01-25T11:27:41.241] [INFO] HttpServerModule - Listening on port 80
+connector-1  | [2021-01-25T11:27:41.241] [INFO] HttpServerModule - Listening on port 8080
 ...
 connector-1  | [2021-01-25T11:27:41.241] [INFO] Runtime - Started all modules.
 ```
@@ -149,7 +149,7 @@ npm run test:local -- testSuiteName
       },
       "database": { "driver": "lokijs", "folder": "./" },
       "logging": { "categories": { "default": { "appenders": ["console"] } } },
-      "infrastructure": { "httpServer": { "apiKey": "<api-key-or-empty-string>", "port": 8080 } },
+      "infrastructure": { "httpServer": { "apiKey": "<api-key-or-empty-string>" } },
       "modules": { "coreHttpApi": { "docs": { "enabled": true } } }
     }
     ```

--- a/helmChart/README.md
+++ b/helmChart/README.md
@@ -45,11 +45,11 @@ config:
     infrastructure:
         httpServer:
             apiKey: "<api-key>"
-            port: 80
+            port: 8080
 
 pod:
     connector:
-        containerPort: 80
+        containerPort: 8080
 
     ferretdb:
         enabled: true

--- a/helmChart/values.yaml
+++ b/helmChart/values.yaml
@@ -43,7 +43,7 @@ pod:
     # https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#resources
     resources: {}
 
-    containerPort: 80
+    containerPort: 8080
 
   # configuration for the FerretDB (https://docs.ferretdb.io) sidecar
   ferretdb:
@@ -74,4 +74,4 @@ service:
   type: ClusterIP
 
   # the service port
-  port: 80
+  port: 8080

--- a/src/infrastructure/httpServer/HttpServer.ts
+++ b/src/infrastructure/httpServer/HttpServer.ts
@@ -278,7 +278,7 @@ export class HttpServer extends ConnectorInfrastructure<HttpServerConfiguration>
     public async start(): Promise<void> {
         this.configure();
         return await new Promise((resolve) => {
-            const port = this.configuration.port ?? 80;
+            const port = this.configuration.port ?? 8080;
             this.server = this.app.listen(port, () => {
                 this.logger.info(`Listening on port ${port}`);
                 resolve();


### PR DESCRIPTION
# Readiness checklist

- [ ] I added/updated tests.
- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [x] I self-reviewed the PR.

# Description

Port 80 requires extended capabilities in kubernetes (`CAP_NET_BIND_SERVICE`), when switching from `alpine` to `node:slim` this capability was removed (see https://github.com/nmshd/connector/pull/354/files).

The error looks as follows:
```
[2025-02-05T18:13:08.212] [ERROR] ConnectorRuntime - Uncaught exception occured:  Error: listen EACCES: permission denied 0.0.0.0:80
    at Server.setupListenHandle [as _listen2] (node:net:1915:21)
    at listenInCluster (node:net:1994:12)
    at Server.listen (node:net:2099:7)
    at Function.listen (/usr/app/node_modules/express/lib/application.js:635:24)
    at /usr/app/dist/infrastructure/httpServer/HttpServer.js:223:36
    at new Promise (<anonymous>)
    at HttpServer.start (/usr/app/dist/infrastructure/httpServer/HttpServer.js:221:22)
    at ConnectorRuntime.startInfrastructure (/usr/app/dist/ConnectorRuntime.js:282:34)
    at ConnectorRuntime.start (/usr/app/node_modules/@nmshd/runtime/dist/Runtime.js:277:20)
    at Object.startConnectorHandler [as handler] (/usr/app/dist/cli/commands/startConnector.js:12:19) {
  code: 'EACCES',
  errno: -13,
  syscall: 'listen',
  address: '0.0.0.0',
  port: 80
} 
```

There were two possibilities to fix this:

1. re-add the capability (and find out how that works on debian)
2. change to port 8080

As it is better practice to not run on port 80 I changed the connector default port to 8080.
