### PR TITLE
Connector does not start on kubernetes

### DIFF
--- a/.dev/Dockerfile.debug
+++ b/.dev/Dockerfile.debug
@@ -2,6 +2,6 @@ FROM node:23.7.0
 WORKDIR /usr/app
 
 # Webserver, Debugger
-EXPOSE 8080 9229
+EXPOSE 80 9229
 
 ENTRYPOINT ["npx", "nodemon", "-e", "js,json,yml", "--watch", "./dist", "--watch", "./config", "--inspect=0.0.0.0:9229", "--nolazy", "./dist/index.js", "start"]

--- a/.dev/compose.prodtest.yml
+++ b/.dev/compose.prodtest.yml
@@ -12,7 +12,7 @@ services:
         COMMIT_HASH: "test"
     container_name: connector
     ports:
-      - "3000:8080" # Webserver
+      - "3000:80" # Webserver
     environment:
       DATABASE_NAME: "prod_connector"
       transportLibrary__baseUrl: "http://consumer-api:8080"

--- a/.dev/compose.yml
+++ b/.dev/compose.yml
@@ -7,7 +7,7 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     ports:
-      - "3000:8080" # Webserver
+      - "3000:80" # Webserver
       - "9229:9229" # Debugger
     environment:
       - CUSTOM_CONFIG_LOCATION=/config.json
@@ -36,7 +36,7 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     ports:
-      - "3001:8080" # Webserver
+      - "3001:80" # Webserver
       - "9231:9229" # Debugger
     environment:
       - CUSTOM_CONFIG_LOCATION=/config.json

--- a/README_dev.md
+++ b/README_dev.md
@@ -34,7 +34,7 @@ After a few seconds you should see the following output:
 ```console
 connector-1  | [2021-01-25T11:27:40.788] [INFO] Transport.Transport - Transport initialized
 ...
-connector-1  | [2021-01-25T11:27:41.241] [INFO] HttpServerModule - Listening on port 8080
+connector-1  | [2021-01-25T11:27:41.241] [INFO] HttpServerModule - Listening on port 80
 ...
 connector-1  | [2021-01-25T11:27:41.241] [INFO] Runtime - Started all modules.
 ```
@@ -149,7 +149,7 @@ npm run test:local -- testSuiteName
       },
       "database": { "driver": "lokijs", "folder": "./" },
       "logging": { "categories": { "default": { "appenders": ["console"] } } },
-      "infrastructure": { "httpServer": { "apiKey": "<api-key-or-empty-string>" } },
+      "infrastructure": { "httpServer": { "apiKey": "<api-key-or-empty-string>", "port": 8080 } },
       "modules": { "coreHttpApi": { "docs": { "enabled": true } } }
     }
     ```

--- a/helmChart/README.md
+++ b/helmChart/README.md
@@ -45,12 +45,8 @@ config:
     infrastructure:
         httpServer:
             apiKey: "<api-key>"
-            port: 80
 
 pod:
-    connector:
-        containerPort: 80
-
     ferretdb:
         enabled: true
         tag: 0.8.1

--- a/helmChart/README.md
+++ b/helmChart/README.md
@@ -45,11 +45,11 @@ config:
     infrastructure:
         httpServer:
             apiKey: "<api-key>"
-            port: 8080
+            port: 80
 
 pod:
     connector:
-        containerPort: 8080
+        containerPort: 80
 
     ferretdb:
         enabled: true

--- a/helmChart/templates/NOTES.txt
+++ b/helmChart/templates/NOTES.txt
@@ -9,7 +9,7 @@ Get the application URL by running these commands:
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "enmeshed_connector.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
   echo http://$SERVICE_IP:{{ .Values.service.port }}
 {{- else if contains "ClusterIP" .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "enmeshed_connector.fullname" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "enmeshed_connector.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
   echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT

--- a/helmChart/templates/deployment.yaml
+++ b/helmChart/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: {{ .Values.pod.connector.containerPort }}
+              containerPort: 8080
               protocol: TCP
           livenessProbe:
             httpGet:
@@ -58,6 +58,8 @@ spec:
             {{- with .Values.pod.connector.environment }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+            - name: infrastructure__httpServer__port
+              value: "8080"
           volumeMounts:
             - name: config-volume
               mountPath: /config.json

--- a/helmChart/values.yaml
+++ b/helmChart/values.yaml
@@ -43,7 +43,7 @@ pod:
     # https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#resources
     resources: {}
 
-    containerPort: 8080
+    containerPort: 80
 
   # configuration for the FerretDB (https://docs.ferretdb.io) sidecar
   ferretdb:
@@ -74,4 +74,4 @@ service:
   type: ClusterIP
 
   # the service port
-  port: 8080
+  port: 80

--- a/helmChart/values.yaml
+++ b/helmChart/values.yaml
@@ -43,8 +43,6 @@ pod:
     # https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#resources
     resources: {}
 
-    containerPort: 80
-
   # configuration for the FerretDB (https://docs.ferretdb.io) sidecar
   ferretdb:
     enabled: false

--- a/src/healthcheck.ts
+++ b/src/healthcheck.ts
@@ -1,3 +1,8 @@
 import http from "http";
+import { createConnectorConfig } from "./CreateConnectorConfig";
 
-http.get("http://localhost/health", (res) => process.exit(res.statusCode === 200 ? 0 : 1));
+const config = createConnectorConfig();
+const port = config.infrastructure.httpServer.port ?? 80;
+const healthCheckUrl = `http://localhost:${port}/health`;
+
+http.get(healthCheckUrl, (res) => process.exit(res.statusCode === 200 ? 0 : 1));

--- a/src/infrastructure/httpServer/HttpServer.ts
+++ b/src/infrastructure/httpServer/HttpServer.ts
@@ -278,7 +278,7 @@ export class HttpServer extends ConnectorInfrastructure<HttpServerConfiguration>
     public async start(): Promise<void> {
         this.configure();
         return await new Promise((resolve) => {
-            const port = this.configuration.port ?? 8080;
+            const port = this.configuration.port ?? 80;
             this.server = this.app.listen(port, () => {
                 this.logger.info(`Listening on port ${port}`);
                 resolve();


### PR DESCRIPTION
# Readiness checklist

- [ ] I added/updated tests.
- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [x] I self-reviewed the PR.

# Description

Reverts #363 because of the unwanted breaking config change (compose users had to manually change the port to 8080).

Additionally:

- changes the port **on kubernetes only** of the pod to 8080, not configurable
- it's still possible to configure the Service port
