### PR TITLE
Connector installs and starts under old NodeJS without a warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -77,6 +77,9 @@
                 "ts-jest": "^29.2.6",
                 "ts-node": "^10.9.2",
                 "typescript": "^5.7.3"
+            },
+            "engines": {
+                "node": ">=22"
             }
         },
         "node_modules/@acuminous/bitsyntax": {

--- a/package.json
+++ b/package.json
@@ -146,5 +146,6 @@
         "typescript": "^5.7.3"
     },
     "engines": {
+        "node": ">=22"
     }
 }

--- a/package.json
+++ b/package.json
@@ -144,5 +144,7 @@
         "ts-jest": "^29.2.6",
         "ts-node": "^10.9.2",
         "typescript": "^5.7.3"
+    },
+    "engines": {
     }
 }


### PR DESCRIPTION
# Readiness checklist

- [ ] I added/updated tests.
- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [x] I self-reviewed the PR.

# Description

When installed using the zip (#366) the connector should make sure to not start / show a warning if an old node version is detected that we don't test for.
