### PR TITLE
Only log to console by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,6 @@ LABEL org.opencontainers.image.source="https://github.com/nmshd/connector"
 
 RUN apt-get update && apt-get -qq install -y --no-install-recommends tini && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-RUN mkdir -p /var/log/enmeshed-connector && chown -R node:node /var/log/enmeshed-connector
-
 WORKDIR /usr/app
 
 COPY package.json package-lock.json ./

--- a/src/createConnectorConfig.ts
+++ b/src/createConnectorConfig.ts
@@ -36,11 +36,6 @@ export function createConnectorConfig(customConfigLocation?: string): ConnectorR
             },
             logging: {
                 appenders: {
-                    fileAppender: {
-                        type: "dateFile",
-                        filename: "/var/log/enmeshed-connector/latest.log",
-                        layout: { type: "pattern", pattern: "[%d] [%p] %c - %m %x{correlationId}" }
-                    },
                     consoleAppender: {
                         type: "stdout",
                         layout: { type: "pattern", pattern: "%[[%d] [%p] %c - %m %x{correlationId}%]" }
@@ -49,17 +44,12 @@ export function createConnectorConfig(customConfigLocation?: string): ConnectorR
                         type: "logLevelFilter",
                         level: "INFO",
                         appender: "consoleAppender"
-                    },
-                    file: {
-                        type: "logLevelFilter",
-                        level: "INFO",
-                        appender: "fileAppender"
                     }
                 },
 
                 categories: {
                     default: {
-                        appenders: ["file", "console"],
+                        appenders: ["console"],
                         level: "TRACE"
                     }
                 }


### PR DESCRIPTION
# Readiness checklist

- [ ] I added/updated tests.
- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [x] I self-reviewed the PR.

# Description

It was not very good idea to add file based logging by default, b/c when it's really required we should make sure that the user knows where logs are stored and how to change these settings.

As a side effect this should help setting the connector up without docker on MacOS and Windows as the path /var/log has been very linux'y