### PR TITLE
Starting a connector without a baseUrl configured throws a confusing error

### DIFF
--- a/src/jsonSchemas/connectorConfig.json
+++ b/src/jsonSchemas/connectorConfig.json
@@ -1099,6 +1099,7 @@
                     "type": "number"
                 }
             },
+            "required": ["baseUrl", "platformClientId", "platformClientSecret"],
             "type": "object"
         }
     },


### PR DESCRIPTION
# Readiness checklist

- [ ] I added/updated tests.
- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [x] I self-reviewed the PR.

<!-- # Description -->
