### PR TITLE
Switch the default QR code format to the new one and remove the old one completely

### DIFF
--- a/packages/sdk/src/endpoints/FilesEndpoint.ts
+++ b/packages/sdk/src/endpoints/FilesEndpoint.ts
@@ -49,7 +49,7 @@ export class FilesEndpoint extends Endpoint {
 
     public async getQrCodeForFile(
         fileId: string,
-        /** @deprecated this will be removed in the future */
+        /** @deprecated this option is available to provide a grace period for all apps to support the new QR code format and will be removed in the future */
         oldQRCodeFormat?: boolean
     ): Promise<ConnectorHttpResponse<ArrayBuffer>> {
         return await this.downloadQrCode("GET", `/api/v2/Files/${fileId}`, { oldQRCodeFormat: oldQRCodeFormat ? "true" : undefined });

--- a/packages/sdk/src/endpoints/FilesEndpoint.ts
+++ b/packages/sdk/src/endpoints/FilesEndpoint.ts
@@ -47,12 +47,8 @@ export class FilesEndpoint extends Endpoint {
         return await this.download(`/api/v2/Files/${fileId}/Download`);
     }
 
-    public async getQrCodeForFile(
-        fileId: string,
-        /** @deprecated this option is available to provide a grace period for all apps to support the new QR code format and will be removed in the future */
-        oldQRCodeFormat?: boolean
-    ): Promise<ConnectorHttpResponse<ArrayBuffer>> {
-        return await this.downloadQrCode("GET", `/api/v2/Files/${fileId}`, { oldQRCodeFormat: oldQRCodeFormat ? "true" : undefined });
+    public async getQrCodeForFile(fileId: string): Promise<ConnectorHttpResponse<ArrayBuffer>> {
+        return await this.downloadQrCode("GET", `/api/v2/Files/${fileId}`);
     }
 
     public async createTokenForFile(fileId: string, request?: CreateTokenForFileRequest): Promise<ConnectorHttpResponse<ConnectorToken>> {

--- a/packages/sdk/src/endpoints/FilesEndpoint.ts
+++ b/packages/sdk/src/endpoints/FilesEndpoint.ts
@@ -47,8 +47,8 @@ export class FilesEndpoint extends Endpoint {
         return await this.download(`/api/v2/Files/${fileId}/Download`);
     }
 
-    public async getQrCodeForFile(fileId: string, newQRCodeFormat?: boolean): Promise<ConnectorHttpResponse<ArrayBuffer>> {
-        return await this.downloadQrCode("GET", `/api/v2/Files/${fileId}`, { newQRCodeFormat: newQRCodeFormat ? "true" : undefined });
+    public async getQrCodeForFile(fileId: string, oldQRCodeFormat?: boolean): Promise<ConnectorHttpResponse<ArrayBuffer>> {
+        return await this.downloadQrCode("GET", `/api/v2/Files/${fileId}`, { oldQRCodeFormat: oldQRCodeFormat ? "true" : undefined });
     }
 
     public async createTokenForFile(fileId: string, request?: CreateTokenForFileRequest): Promise<ConnectorHttpResponse<ConnectorToken>> {

--- a/packages/sdk/src/endpoints/FilesEndpoint.ts
+++ b/packages/sdk/src/endpoints/FilesEndpoint.ts
@@ -47,7 +47,11 @@ export class FilesEndpoint extends Endpoint {
         return await this.download(`/api/v2/Files/${fileId}/Download`);
     }
 
-    public async getQrCodeForFile(fileId: string, oldQRCodeFormat?: boolean): Promise<ConnectorHttpResponse<ArrayBuffer>> {
+    public async getQrCodeForFile(
+        fileId: string,
+        /** @deprecated this will be removed in the future */
+        oldQRCodeFormat?: boolean
+    ): Promise<ConnectorHttpResponse<ArrayBuffer>> {
         return await this.downloadQrCode("GET", `/api/v2/Files/${fileId}`, { oldQRCodeFormat: oldQRCodeFormat ? "true" : undefined });
     }
 

--- a/packages/sdk/src/endpoints/RelationshipTemplatesEndpoint.ts
+++ b/packages/sdk/src/endpoints/RelationshipTemplatesEndpoint.ts
@@ -37,7 +37,7 @@ export class RelationshipTemplatesEndpoint extends Endpoint {
 
     public async getQrCodeForOwnRelationshipTemplate(
         id: string,
-        /** @deprecated this will be removed in the future */
+        /** @deprecated this option is available to provide a grace period for all apps to support the new QR code format and will be removed in the future */
         oldQRCodeFormat?: boolean
     ): Promise<ConnectorHttpResponse<ArrayBuffer>> {
         return await this.downloadQrCode("GET", `/api/v2/RelationshipTemplates/${id}`, { oldQRCodeFormat: oldQRCodeFormat ? "true" : undefined });

--- a/packages/sdk/src/endpoints/RelationshipTemplatesEndpoint.ts
+++ b/packages/sdk/src/endpoints/RelationshipTemplatesEndpoint.ts
@@ -35,12 +35,8 @@ export class RelationshipTemplatesEndpoint extends Endpoint {
         return await this.post("/api/v2/RelationshipTemplates/Own", request);
     }
 
-    public async getQrCodeForOwnRelationshipTemplate(
-        id: string,
-        /** @deprecated this option is available to provide a grace period for all apps to support the new QR code format and will be removed in the future */
-        oldQRCodeFormat?: boolean
-    ): Promise<ConnectorHttpResponse<ArrayBuffer>> {
-        return await this.downloadQrCode("GET", `/api/v2/RelationshipTemplates/${id}`, { oldQRCodeFormat: oldQRCodeFormat ? "true" : undefined });
+    public async getQrCodeForOwnRelationshipTemplate(id: string): Promise<ConnectorHttpResponse<ArrayBuffer>> {
+        return await this.downloadQrCode("GET", `/api/v2/RelationshipTemplates/${id}`);
     }
 
     public async createTokenForOwnRelationshipTemplate(id: string, request?: CreateTokenForOwnRelationshipTemplateRequest): Promise<ConnectorHttpResponse<ConnectorToken>> {

--- a/packages/sdk/src/endpoints/RelationshipTemplatesEndpoint.ts
+++ b/packages/sdk/src/endpoints/RelationshipTemplatesEndpoint.ts
@@ -35,8 +35,8 @@ export class RelationshipTemplatesEndpoint extends Endpoint {
         return await this.post("/api/v2/RelationshipTemplates/Own", request);
     }
 
-    public async getQrCodeForOwnRelationshipTemplate(id: string, newQRCodeFormat?: boolean): Promise<ConnectorHttpResponse<ArrayBuffer>> {
-        return await this.downloadQrCode("GET", `/api/v2/RelationshipTemplates/${id}`, { newQRCodeFormat: newQRCodeFormat ? "true" : undefined });
+    public async getQrCodeForOwnRelationshipTemplate(id: string, oldQRCodeFormat?: boolean): Promise<ConnectorHttpResponse<ArrayBuffer>> {
+        return await this.downloadQrCode("GET", `/api/v2/RelationshipTemplates/${id}`, { oldQRCodeFormat: oldQRCodeFormat ? "true" : undefined });
     }
 
     public async createTokenForOwnRelationshipTemplate(id: string, request?: CreateTokenForOwnRelationshipTemplateRequest): Promise<ConnectorHttpResponse<ConnectorToken>> {

--- a/packages/sdk/src/endpoints/RelationshipTemplatesEndpoint.ts
+++ b/packages/sdk/src/endpoints/RelationshipTemplatesEndpoint.ts
@@ -35,7 +35,11 @@ export class RelationshipTemplatesEndpoint extends Endpoint {
         return await this.post("/api/v2/RelationshipTemplates/Own", request);
     }
 
-    public async getQrCodeForOwnRelationshipTemplate(id: string, oldQRCodeFormat?: boolean): Promise<ConnectorHttpResponse<ArrayBuffer>> {
+    public async getQrCodeForOwnRelationshipTemplate(
+        id: string,
+        /** @deprecated this will be removed in the future */
+        oldQRCodeFormat?: boolean
+    ): Promise<ConnectorHttpResponse<ArrayBuffer>> {
         return await this.downloadQrCode("GET", `/api/v2/RelationshipTemplates/${id}`, { oldQRCodeFormat: oldQRCodeFormat ? "true" : undefined });
     }
 

--- a/packages/sdk/src/endpoints/TokensEndpoint.ts
+++ b/packages/sdk/src/endpoints/TokensEndpoint.ts
@@ -11,8 +11,8 @@ export class TokensEndpoint extends Endpoint {
         return await this.get(`/api/v2/Tokens/${tokenId}`);
     }
 
-    public async getQrCodeForToken(tokenId: string, newQRCodeFormat?: boolean): Promise<ConnectorHttpResponse<ArrayBuffer>> {
-        return await this.downloadQrCode("GET", `/api/v2/Tokens/${tokenId}`, { newQRCodeFormat: newQRCodeFormat ? "true" : undefined });
+    public async getQrCodeForToken(tokenId: string, oldQRCodeFormat?: boolean): Promise<ConnectorHttpResponse<ArrayBuffer>> {
+        return await this.downloadQrCode("GET", `/api/v2/Tokens/${tokenId}`, { oldQRCodeFormat: oldQRCodeFormat ? "true" : undefined });
     }
 
     public async getOwnTokens(request?: GetOwnTokensRequest): Promise<ConnectorHttpResponse<ConnectorTokens>> {

--- a/packages/sdk/src/endpoints/TokensEndpoint.ts
+++ b/packages/sdk/src/endpoints/TokensEndpoint.ts
@@ -11,12 +11,8 @@ export class TokensEndpoint extends Endpoint {
         return await this.get(`/api/v2/Tokens/${tokenId}`);
     }
 
-    public async getQrCodeForToken(
-        tokenId: string,
-        /** @deprecated this option is available to provide a grace period for all apps to support the new QR code format and will be removed in the future */
-        oldQRCodeFormat?: boolean
-    ): Promise<ConnectorHttpResponse<ArrayBuffer>> {
-        return await this.downloadQrCode("GET", `/api/v2/Tokens/${tokenId}`, { oldQRCodeFormat: oldQRCodeFormat ? "true" : undefined });
+    public async getQrCodeForToken(tokenId: string): Promise<ConnectorHttpResponse<ArrayBuffer>> {
+        return await this.downloadQrCode("GET", `/api/v2/Tokens/${tokenId}`);
     }
 
     public async getOwnTokens(request?: GetOwnTokensRequest): Promise<ConnectorHttpResponse<ConnectorTokens>> {

--- a/packages/sdk/src/endpoints/TokensEndpoint.ts
+++ b/packages/sdk/src/endpoints/TokensEndpoint.ts
@@ -13,7 +13,7 @@ export class TokensEndpoint extends Endpoint {
 
     public async getQrCodeForToken(
         tokenId: string,
-        /** @deprecated this will be removed in the future */
+        /** @deprecated this option is available to provide a grace period for all apps to support the new QR code format and will be removed in the future */
         oldQRCodeFormat?: boolean
     ): Promise<ConnectorHttpResponse<ArrayBuffer>> {
         return await this.downloadQrCode("GET", `/api/v2/Tokens/${tokenId}`, { oldQRCodeFormat: oldQRCodeFormat ? "true" : undefined });

--- a/packages/sdk/src/endpoints/TokensEndpoint.ts
+++ b/packages/sdk/src/endpoints/TokensEndpoint.ts
@@ -11,7 +11,11 @@ export class TokensEndpoint extends Endpoint {
         return await this.get(`/api/v2/Tokens/${tokenId}`);
     }
 
-    public async getQrCodeForToken(tokenId: string, oldQRCodeFormat?: boolean): Promise<ConnectorHttpResponse<ArrayBuffer>> {
+    public async getQrCodeForToken(
+        tokenId: string,
+        /** @deprecated this will be removed in the future */
+        oldQRCodeFormat?: boolean
+    ): Promise<ConnectorHttpResponse<ArrayBuffer>> {
         return await this.downloadQrCode("GET", `/api/v2/Tokens/${tokenId}`, { oldQRCodeFormat: oldQRCodeFormat ? "true" : undefined });
     }
 

--- a/packages/sdk/src/types/files/requests/CreateTokenQrCodeForFileRequest.ts
+++ b/packages/sdk/src/types/files/requests/CreateTokenQrCodeForFileRequest.ts
@@ -6,6 +6,4 @@ export interface CreateTokenQrCodeForFileRequest {
         passwordIsPin?: true;
         passwordLocationIndicator?: string | number;
     };
-    /** @deprecated this option is available to provide a grace period for all apps to support the new QR code format and will be removed in the future */
-    oldQRCodeFormat?: boolean;
 }

--- a/packages/sdk/src/types/files/requests/CreateTokenQrCodeForFileRequest.ts
+++ b/packages/sdk/src/types/files/requests/CreateTokenQrCodeForFileRequest.ts
@@ -6,5 +6,6 @@ export interface CreateTokenQrCodeForFileRequest {
         passwordIsPin?: true;
         passwordLocationIndicator?: string | number;
     };
+    /** @deprecated this will be removed in the future */
     oldQRCodeFormat?: boolean;
 }

--- a/packages/sdk/src/types/files/requests/CreateTokenQrCodeForFileRequest.ts
+++ b/packages/sdk/src/types/files/requests/CreateTokenQrCodeForFileRequest.ts
@@ -6,5 +6,5 @@ export interface CreateTokenQrCodeForFileRequest {
         passwordIsPin?: true;
         passwordLocationIndicator?: string | number;
     };
-    newQRCodeFormat?: boolean;
+    oldQRCodeFormat?: boolean;
 }

--- a/packages/sdk/src/types/files/requests/CreateTokenQrCodeForFileRequest.ts
+++ b/packages/sdk/src/types/files/requests/CreateTokenQrCodeForFileRequest.ts
@@ -6,6 +6,6 @@ export interface CreateTokenQrCodeForFileRequest {
         passwordIsPin?: true;
         passwordLocationIndicator?: string | number;
     };
-    /** @deprecated this will be removed in the future */
+    /** @deprecated this option is available to provide a grace period for all apps to support the new QR code format and will be removed in the future */
     oldQRCodeFormat?: boolean;
 }

--- a/packages/sdk/src/types/relationshipTemplates/requests/CreateTokenQrCodeForOwnRelationshipTemplateRequest.ts
+++ b/packages/sdk/src/types/relationshipTemplates/requests/CreateTokenQrCodeForOwnRelationshipTemplateRequest.ts
@@ -6,5 +6,6 @@ export interface CreateTokenQrCodeForOwnRelationshipTemplateRequest {
         passwordIsPin?: true;
         passwordLocationIndicator?: string | number;
     };
+    /** @deprecated this will be removed in the future */
     oldQRCodeFormat?: boolean;
 }

--- a/packages/sdk/src/types/relationshipTemplates/requests/CreateTokenQrCodeForOwnRelationshipTemplateRequest.ts
+++ b/packages/sdk/src/types/relationshipTemplates/requests/CreateTokenQrCodeForOwnRelationshipTemplateRequest.ts
@@ -6,5 +6,5 @@ export interface CreateTokenQrCodeForOwnRelationshipTemplateRequest {
         passwordIsPin?: true;
         passwordLocationIndicator?: string | number;
     };
-    newQRCodeFormat?: boolean;
+    oldQRCodeFormat?: boolean;
 }

--- a/packages/sdk/src/types/relationshipTemplates/requests/CreateTokenQrCodeForOwnRelationshipTemplateRequest.ts
+++ b/packages/sdk/src/types/relationshipTemplates/requests/CreateTokenQrCodeForOwnRelationshipTemplateRequest.ts
@@ -6,6 +6,6 @@ export interface CreateTokenQrCodeForOwnRelationshipTemplateRequest {
         passwordIsPin?: true;
         passwordLocationIndicator?: string | number;
     };
-    /** @deprecated this will be removed in the future */
+    /** @deprecated this option is available to provide a grace period for all apps to support the new QR code format and will be removed in the future */
     oldQRCodeFormat?: boolean;
 }

--- a/packages/sdk/src/types/relationshipTemplates/requests/CreateTokenQrCodeForOwnRelationshipTemplateRequest.ts
+++ b/packages/sdk/src/types/relationshipTemplates/requests/CreateTokenQrCodeForOwnRelationshipTemplateRequest.ts
@@ -6,6 +6,4 @@ export interface CreateTokenQrCodeForOwnRelationshipTemplateRequest {
         passwordIsPin?: true;
         passwordLocationIndicator?: string | number;
     };
-    /** @deprecated this option is available to provide a grace period for all apps to support the new QR code format and will be removed in the future */
-    oldQRCodeFormat?: boolean;
 }

--- a/src/modules/coreHttpApi/controllers/FilesController.ts
+++ b/src/modules/coreHttpApi/controllers/FilesController.ts
@@ -101,7 +101,7 @@ export class FilesController extends BaseController {
         @PathParam("idOrReference") idOrReference: string,
         @ContextAccept accept: string,
         @ContextResponse response: express.Response,
-        @QueryParam("newQRCodeFormat") newQRCodeFormat?: boolean
+        @QueryParam("oldQRCodeFormat") oldQRCodeFormat?: boolean
     ): Promise<Envelope | void> {
         const fileId = idOrReference.startsWith("FIL") ? idOrReference : Reference.fromTruncated(idOrReference).id.toString();
 
@@ -109,7 +109,7 @@ export class FilesController extends BaseController {
 
         switch (accept) {
             case "image/png":
-                return await this.qrCode(result, (r) => QRCode.for(newQRCodeFormat ? r.value.reference.url : r.value.reference.truncated), `${fileId}.png`, response, 200);
+                return await this.qrCode(result, (r) => QRCode.for(oldQRCodeFormat ? r.value.reference.truncated : r.value.reference.url), `${fileId}.png`, response, 200);
             default:
                 return this.ok(result);
         }
@@ -124,8 +124,8 @@ export class FilesController extends BaseController {
         @ContextResponse response: express.Response,
         request: any
     ): Promise<Return.NewResource<Envelope> | void> {
-        const newQRCodeFormat = request["newQRCodeFormat"] === true;
-        delete request["newQRCodeFormat"];
+        const oldQRCodeFormat = request["oldQRCodeFormat"] === true;
+        delete request["oldQRCodeFormat"];
 
         const result = await this.transportServices.files.createTokenForFile({
             fileId: id,
@@ -137,7 +137,7 @@ export class FilesController extends BaseController {
 
         switch (accept) {
             case "image/png":
-                return await this.qrCode(result, (r) => QRCode.for(newQRCodeFormat ? r.value.reference.url : r.value.reference.truncated), `${id}.png`, response, 201);
+                return await this.qrCode(result, (r) => QRCode.for(oldQRCodeFormat ? r.value.reference.truncated : r.value.reference.url), `${id}.png`, response, 201);
             default:
                 return this.created(result);
         }

--- a/src/modules/coreHttpApi/controllers/FilesController.ts
+++ b/src/modules/coreHttpApi/controllers/FilesController.ts
@@ -2,22 +2,7 @@ import { BaseController, Envelope, Mimetype, QRCode } from "@nmshd/connector-typ
 import { Reference } from "@nmshd/core-types";
 import { OwnerRestriction, TransportServices } from "@nmshd/runtime";
 import { Inject } from "@nmshd/typescript-ioc";
-import {
-    Accept,
-    Context,
-    ContextAccept,
-    ContextResponse,
-    DELETE,
-    FileParam,
-    FormParam,
-    GET,
-    Path,
-    PathParam,
-    POST,
-    QueryParam,
-    Return,
-    ServiceContext
-} from "@nmshd/typescript-rest";
+import { Accept, Context, ContextAccept, ContextResponse, DELETE, FileParam, FormParam, GET, Path, PathParam, POST, Return, ServiceContext } from "@nmshd/typescript-rest";
 import express from "express";
 
 @Path("/api/v2/Files")
@@ -97,19 +82,14 @@ export class FilesController extends BaseController {
     @GET
     @Path("/:idOrReference")
     @Accept("application/json", "image/png")
-    public async getFile(
-        @PathParam("idOrReference") idOrReference: string,
-        @ContextAccept accept: string,
-        @ContextResponse response: express.Response,
-        @QueryParam("oldQRCodeFormat") oldQRCodeFormat?: boolean
-    ): Promise<Envelope | void> {
+    public async getFile(@PathParam("idOrReference") idOrReference: string, @ContextAccept accept: string, @ContextResponse response: express.Response): Promise<Envelope | void> {
         const fileId = idOrReference.startsWith("FIL") ? idOrReference : Reference.fromTruncated(idOrReference).id.toString();
 
         const result = await this.transportServices.files.getFile({ id: fileId });
 
         switch (accept) {
             case "image/png":
-                return await this.qrCode(result, (r) => QRCode.for(oldQRCodeFormat ? r.value.reference.truncated : r.value.reference.url), `${fileId}.png`, response, 200);
+                return await this.qrCode(result, (r) => QRCode.for(r.value.reference.url), `${fileId}.png`, response, 200);
             default:
                 return this.ok(result);
         }
@@ -124,9 +104,6 @@ export class FilesController extends BaseController {
         @ContextResponse response: express.Response,
         request: any
     ): Promise<Return.NewResource<Envelope> | void> {
-        const oldQRCodeFormat = request["oldQRCodeFormat"] === true;
-        delete request["oldQRCodeFormat"];
-
         const result = await this.transportServices.files.createTokenForFile({
             fileId: id,
             expiresAt: request.expiresAt,
@@ -137,7 +114,7 @@ export class FilesController extends BaseController {
 
         switch (accept) {
             case "image/png":
-                return await this.qrCode(result, (r) => QRCode.for(oldQRCodeFormat ? r.value.reference.truncated : r.value.reference.url), `${id}.png`, response, 201);
+                return await this.qrCode(result, (r) => QRCode.for(r.value.reference.url), `${id}.png`, response, 201);
             default:
                 return this.created(result);
         }

--- a/src/modules/coreHttpApi/controllers/RelationshipTemplatesController.ts
+++ b/src/modules/coreHttpApi/controllers/RelationshipTemplatesController.ts
@@ -47,13 +47,13 @@ export class RelationshipTemplatesController extends BaseController {
         @PathParam("id") id: string,
         @ContextAccept accept: string,
         @ContextResponse response: express.Response,
-        @QueryParam("newQRCodeFormat") newQRCodeFormat?: boolean
+        @QueryParam("oldQRCodeFormat") oldQRCodeFormat?: boolean
     ): Promise<Envelope | void> {
         const result = await this.transportServices.relationshipTemplates.getRelationshipTemplate({ id });
 
         switch (accept) {
             case "image/png":
-                return await this.qrCode(result, (r) => QRCode.for(newQRCodeFormat ? r.value.reference.url : r.value.reference.truncated), `${id}.png`, response, 200);
+                return await this.qrCode(result, (r) => QRCode.for(oldQRCodeFormat ? r.value.reference.truncated : r.value.reference.url), `${id}.png`, response, 200);
             default:
                 return this.ok(result);
         }
@@ -84,8 +84,8 @@ export class RelationshipTemplatesController extends BaseController {
         @ContextResponse response: express.Response,
         request: any
     ): Promise<Return.NewResource<Envelope> | void> {
-        const newQRCodeFormat = request["newQRCodeFormat"] === true;
-        delete request["newQRCodeFormat"];
+        const oldQRCodeFormat = request["oldQRCodeFormat"] === true;
+        delete request["oldQRCodeFormat"];
 
         const result = await this.transportServices.relationshipTemplates.createTokenForOwnRelationshipTemplate({
             templateId: id,
@@ -97,7 +97,7 @@ export class RelationshipTemplatesController extends BaseController {
 
         switch (accept) {
             case "image/png":
-                return await this.qrCode(result, (r) => QRCode.for(newQRCodeFormat ? r.value.reference.url : r.value.reference.truncated), `${id}.png`, response, 201);
+                return await this.qrCode(result, (r) => QRCode.for(oldQRCodeFormat ? r.value.reference.truncated : r.value.reference.url), `${id}.png`, response, 201);
             default:
                 return this.created(result);
         }

--- a/src/modules/coreHttpApi/controllers/RelationshipTemplatesController.ts
+++ b/src/modules/coreHttpApi/controllers/RelationshipTemplatesController.ts
@@ -1,7 +1,7 @@
 import { BaseController, Envelope, QRCode } from "@nmshd/connector-types";
 import { OwnerRestriction, TransportServices } from "@nmshd/runtime";
 import { Inject } from "@nmshd/typescript-ioc";
-import { Accept, Context, ContextAccept, ContextResponse, GET, POST, Path, PathParam, QueryParam, Return, ServiceContext } from "@nmshd/typescript-rest";
+import { Accept, Context, ContextAccept, ContextResponse, GET, POST, Path, PathParam, Return, ServiceContext } from "@nmshd/typescript-rest";
 import express from "express";
 
 @Path("/api/v2/RelationshipTemplates")
@@ -43,17 +43,12 @@ export class RelationshipTemplatesController extends BaseController {
     @GET
     @Path("/:id")
     @Accept("application/json", "image/png")
-    public async getRelationshipTemplate(
-        @PathParam("id") id: string,
-        @ContextAccept accept: string,
-        @ContextResponse response: express.Response,
-        @QueryParam("oldQRCodeFormat") oldQRCodeFormat?: boolean
-    ): Promise<Envelope | void> {
+    public async getRelationshipTemplate(@PathParam("id") id: string, @ContextAccept accept: string, @ContextResponse response: express.Response): Promise<Envelope | void> {
         const result = await this.transportServices.relationshipTemplates.getRelationshipTemplate({ id });
 
         switch (accept) {
             case "image/png":
-                return await this.qrCode(result, (r) => QRCode.for(oldQRCodeFormat ? r.value.reference.truncated : r.value.reference.url), `${id}.png`, response, 200);
+                return await this.qrCode(result, (r) => QRCode.for(r.value.reference.url), `${id}.png`, response, 200);
             default:
                 return this.ok(result);
         }
@@ -84,9 +79,6 @@ export class RelationshipTemplatesController extends BaseController {
         @ContextResponse response: express.Response,
         request: any
     ): Promise<Return.NewResource<Envelope> | void> {
-        const oldQRCodeFormat = request["oldQRCodeFormat"] === true;
-        delete request["oldQRCodeFormat"];
-
         const result = await this.transportServices.relationshipTemplates.createTokenForOwnRelationshipTemplate({
             templateId: id,
             expiresAt: request.expiresAt,
@@ -97,7 +89,7 @@ export class RelationshipTemplatesController extends BaseController {
 
         switch (accept) {
             case "image/png":
-                return await this.qrCode(result, (r) => QRCode.for(oldQRCodeFormat ? r.value.reference.truncated : r.value.reference.url), `${id}.png`, response, 201);
+                return await this.qrCode(result, (r) => QRCode.for(r.value.reference.url), `${id}.png`, response, 201);
             default:
                 return this.created(result);
         }

--- a/src/modules/coreHttpApi/controllers/TokensController.ts
+++ b/src/modules/coreHttpApi/controllers/TokensController.ts
@@ -1,7 +1,7 @@
 import { BaseController, Envelope, QRCode } from "@nmshd/connector-types";
 import { OwnerRestriction, TransportServices } from "@nmshd/runtime";
 import { Inject } from "@nmshd/typescript-ioc";
-import { Accept, Context, ContextAccept, ContextResponse, GET, Path, PathParam, POST, QueryParam, Return, ServiceContext } from "@nmshd/typescript-rest";
+import { Accept, Context, ContextAccept, ContextResponse, GET, Path, PathParam, POST, Return, ServiceContext } from "@nmshd/typescript-rest";
 import express from "express";
 
 @Path("/api/v2/Tokens")
@@ -53,17 +53,12 @@ export class TokensController extends BaseController {
     @GET
     @Path("/:id")
     @Accept("application/json", "image/png")
-    public async getToken(
-        @PathParam("id") id: string,
-        @ContextAccept accept: string,
-        @ContextResponse response: express.Response,
-        @QueryParam("oldQRCodeFormat") oldQRCodeFormat?: boolean
-    ): Promise<Envelope | void> {
+    public async getToken(@PathParam("id") id: string, @ContextAccept accept: string, @ContextResponse response: express.Response): Promise<Envelope | void> {
         const result = await this.transportServices.tokens.getToken({ id });
 
         switch (accept) {
             case "image/png":
-                return await this.qrCode(result, (r) => QRCode.for(oldQRCodeFormat ? r.value.reference.truncated : r.value.reference.url), `${id}.png`, response, 200);
+                return await this.qrCode(result, (r) => QRCode.for(r.value.reference.url), `${id}.png`, response, 200);
             default:
                 return this.ok(result);
         }

--- a/src/modules/coreHttpApi/controllers/TokensController.ts
+++ b/src/modules/coreHttpApi/controllers/TokensController.ts
@@ -57,13 +57,13 @@ export class TokensController extends BaseController {
         @PathParam("id") id: string,
         @ContextAccept accept: string,
         @ContextResponse response: express.Response,
-        @QueryParam("newQRCodeFormat") newQRCodeFormat?: boolean
+        @QueryParam("oldQRCodeFormat") oldQRCodeFormat?: boolean
     ): Promise<Envelope | void> {
         const result = await this.transportServices.tokens.getToken({ id });
 
         switch (accept) {
             case "image/png":
-                return await this.qrCode(result, (r) => QRCode.for(newQRCodeFormat ? r.value.reference.url : r.value.reference.truncated), `${id}.png`, response, 200);
+                return await this.qrCode(result, (r) => QRCode.for(oldQRCodeFormat ? r.value.reference.truncated : r.value.reference.url), `${id}.png`, response, 200);
             default:
                 return this.ok(result);
         }

--- a/src/modules/coreHttpApi/openapi.yml
+++ b/src/modules/coreHttpApi/openapi.yml
@@ -2131,7 +2131,7 @@ paths:
               - $ref: "#/components/schemas/FileReferenceTruncated"
         - in: query
           name: oldQRCodeFormat
-          description: If set to true, the QRCode will contain the old url format. This is only relevant if the accept header is set to `image/png`.
+          description: If set to true, the QRCode will contain the old url format. This is only relevant if the accept header is set to `image/png`. This option is deprecated and will be removed in the future.
           required: false
           schema:
             type: boolean
@@ -2242,7 +2242,7 @@ paths:
                   description: The password that will be required to load this Token and information about the password.
                 oldQRCodeFormat:
                   type: boolean
-                  description: If set to true, the QRCode will contain the old url format. This is only relevant if the accept header is set to `image/png`.
+                  description: If set to true, the QRCode will contain the old url format. This is only relevant if the accept header is set to `image/png`. This option is deprecated and will be removed in the future.
                   nullable: true
       responses:
         201:
@@ -3666,7 +3666,7 @@ paths:
             $ref: "#/components/schemas/RelationshipTemplateID"
         - in: query
           name: oldQRCodeFormat
-          description: If set to true, the QRCode will contain the old url format. This is only relevant if the accept header is set to `image/png`.
+          description: If set to true, the QRCode will contain the old url format. This is only relevant if the accept header is set to `image/png`. This option is deprecated and will be removed in the future.
           required: false
           schema:
             type: boolean
@@ -3739,7 +3739,7 @@ paths:
                   description: The password that will be required to load this Token and information about the password. If passwordProtection is set for the RelationshipTemplate, the same passwordProtection must also be given here.
                 oldQRCodeFormat:
                   type: boolean
-                  description: If set to true, the QRCode will contain the old url format. This is only relevant if the accept header is set to `image/png`.
+                  description: If set to true, the QRCode will contain the old url format. This is only relevant if the accept header is set to `image/png`. This option is deprecated and will be removed in the future.
                   nullable: true
       responses:
         201:
@@ -4568,7 +4568,7 @@ paths:
             $ref: "#/components/schemas/TokenID"
         - in: query
           name: oldQRCodeFormat
-          description: If set to true, the QRCode will contain the old url format. This is only relevant if the accept header is set to `image/png`.
+          description: If set to true, the QRCode will contain the old url format. This is only relevant if the accept header is set to `image/png`. This option is deprecated and will be removed in the future.
           required: false
           schema:
             type: boolean

--- a/src/modules/coreHttpApi/openapi.yml
+++ b/src/modules/coreHttpApi/openapi.yml
@@ -2129,13 +2129,6 @@ paths:
             oneOf:
               - $ref: "#/components/schemas/FileID"
               - $ref: "#/components/schemas/FileReferenceTruncated"
-        - in: query
-          name: oldQRCodeFormat
-          description: If set to true, the QRCode will contain the old url format. This is only relevant if the accept header is set to `image/png`. This option is available to provide a grace period for all apps to support the new QR code format and will be removed in the future.
-          required: false
-          schema:
-            type: boolean
-            default: false
 
       responses:
         200:
@@ -2240,10 +2233,6 @@ paths:
                   $ref: "#/components/schemas/PasswordProtection"
                   nullable: true
                   description: The password that will be required to load this Token and information about the password.
-                oldQRCodeFormat:
-                  type: boolean
-                  description: If set to true, the QRCode will contain the old url format. This is only relevant if the accept header is set to `image/png`. This option is available to provide a grace period for all apps to support the new QR code format and will be removed in the future.
-                  nullable: true
       responses:
         201:
           description: Success
@@ -3664,13 +3653,6 @@ paths:
           required: true
           schema:
             $ref: "#/components/schemas/RelationshipTemplateID"
-        - in: query
-          name: oldQRCodeFormat
-          description: If set to true, the QRCode will contain the old url format. This is only relevant if the accept header is set to `image/png`. This option is available to provide a grace period for all apps to support the new QR code format and will be removed in the future.
-          required: false
-          schema:
-            type: boolean
-            default: false
       responses:
         200:
           description: Success
@@ -3737,10 +3719,6 @@ paths:
                   $ref: "#/components/schemas/PasswordProtection"
                   nullable: true
                   description: The password that will be required to load this Token and information about the password. If passwordProtection is set for the RelationshipTemplate, the same passwordProtection must also be given here.
-                oldQRCodeFormat:
-                  type: boolean
-                  description: If set to true, the QRCode will contain the old url format. This is only relevant if the accept header is set to `image/png`. This option is available to provide a grace period for all apps to support the new QR code format and will be removed in the future.
-                  nullable: true
       responses:
         201:
           description: Success
@@ -4566,13 +4544,6 @@ paths:
           required: true
           schema:
             $ref: "#/components/schemas/TokenID"
-        - in: query
-          name: oldQRCodeFormat
-          description: If set to true, the QRCode will contain the old url format. This is only relevant if the accept header is set to `image/png`. This option is available to provide a grace period for all apps to support the new QR code format and will be removed in the future.
-          required: false
-          schema:
-            type: boolean
-            default: false
       responses:
         200:
           description: Success

--- a/src/modules/coreHttpApi/openapi.yml
+++ b/src/modules/coreHttpApi/openapi.yml
@@ -2130,8 +2130,8 @@ paths:
               - $ref: "#/components/schemas/FileID"
               - $ref: "#/components/schemas/FileReferenceTruncated"
         - in: query
-          name: newQRCodeFormat
-          description: If set to true, the QRCode will contain the new url format. This is only relevant if the accept header is set to `image/png`.
+          name: oldQRCodeFormat
+          description: If set to true, the QRCode will contain the old url format. This is only relevant if the accept header is set to `image/png`.
           required: false
           schema:
             type: boolean
@@ -2240,9 +2240,9 @@ paths:
                   $ref: "#/components/schemas/PasswordProtection"
                   nullable: true
                   description: The password that will be required to load this Token and information about the password.
-                newQRCodeFormat:
+                oldQRCodeFormat:
                   type: boolean
-                  description: If set to true, the QRCode will contain the new url format. This is only relevant if the accept header is set to `image/png`.
+                  description: If set to true, the QRCode will contain the old url format. This is only relevant if the accept header is set to `image/png`.
                   nullable: true
       responses:
         201:
@@ -3665,8 +3665,8 @@ paths:
           schema:
             $ref: "#/components/schemas/RelationshipTemplateID"
         - in: query
-          name: newQRCodeFormat
-          description: If set to true, the QRCode will contain the new url format. This is only relevant if the accept header is set to `image/png`.
+          name: oldQRCodeFormat
+          description: If set to true, the QRCode will contain the old url format. This is only relevant if the accept header is set to `image/png`.
           required: false
           schema:
             type: boolean
@@ -3737,9 +3737,9 @@ paths:
                   $ref: "#/components/schemas/PasswordProtection"
                   nullable: true
                   description: The password that will be required to load this Token and information about the password. If passwordProtection is set for the RelationshipTemplate, the same passwordProtection must also be given here.
-                newQRCodeFormat:
+                oldQRCodeFormat:
                   type: boolean
-                  description: If set to true, the QRCode will contain the new url format. This is only relevant if the accept header is set to `image/png`.
+                  description: If set to true, the QRCode will contain the old url format. This is only relevant if the accept header is set to `image/png`.
                   nullable: true
       responses:
         201:
@@ -4567,8 +4567,8 @@ paths:
           schema:
             $ref: "#/components/schemas/TokenID"
         - in: query
-          name: newQRCodeFormat
-          description: If set to true, the QRCode will contain the new url format. This is only relevant if the accept header is set to `image/png`.
+          name: oldQRCodeFormat
+          description: If set to true, the QRCode will contain the old url format. This is only relevant if the accept header is set to `image/png`.
           required: false
           schema:
             type: boolean

--- a/src/modules/coreHttpApi/openapi.yml
+++ b/src/modules/coreHttpApi/openapi.yml
@@ -2131,7 +2131,7 @@ paths:
               - $ref: "#/components/schemas/FileReferenceTruncated"
         - in: query
           name: oldQRCodeFormat
-          description: If set to true, the QRCode will contain the old url format. This is only relevant if the accept header is set to `image/png`. This option is deprecated and will be removed in the future.
+          description: If set to true, the QRCode will contain the old url format. This is only relevant if the accept header is set to `image/png`. This option is available to provide a grace period for all apps to support the new QR code format and will be removed in the future.
           required: false
           schema:
             type: boolean
@@ -2242,7 +2242,7 @@ paths:
                   description: The password that will be required to load this Token and information about the password.
                 oldQRCodeFormat:
                   type: boolean
-                  description: If set to true, the QRCode will contain the old url format. This is only relevant if the accept header is set to `image/png`. This option is deprecated and will be removed in the future.
+                  description: If set to true, the QRCode will contain the old url format. This is only relevant if the accept header is set to `image/png`. This option is available to provide a grace period for all apps to support the new QR code format and will be removed in the future.
                   nullable: true
       responses:
         201:
@@ -3666,7 +3666,7 @@ paths:
             $ref: "#/components/schemas/RelationshipTemplateID"
         - in: query
           name: oldQRCodeFormat
-          description: If set to true, the QRCode will contain the old url format. This is only relevant if the accept header is set to `image/png`. This option is deprecated and will be removed in the future.
+          description: If set to true, the QRCode will contain the old url format. This is only relevant if the accept header is set to `image/png`. This option is available to provide a grace period for all apps to support the new QR code format and will be removed in the future.
           required: false
           schema:
             type: boolean
@@ -3739,7 +3739,7 @@ paths:
                   description: The password that will be required to load this Token and information about the password. If passwordProtection is set for the RelationshipTemplate, the same passwordProtection must also be given here.
                 oldQRCodeFormat:
                   type: boolean
-                  description: If set to true, the QRCode will contain the old url format. This is only relevant if the accept header is set to `image/png`. This option is deprecated and will be removed in the future.
+                  description: If set to true, the QRCode will contain the old url format. This is only relevant if the accept header is set to `image/png`. This option is available to provide a grace period for all apps to support the new QR code format and will be removed in the future.
                   nullable: true
       responses:
         201:
@@ -4568,7 +4568,7 @@ paths:
             $ref: "#/components/schemas/TokenID"
         - in: query
           name: oldQRCodeFormat
-          description: If set to true, the QRCode will contain the old url format. This is only relevant if the accept header is set to `image/png`. This option is deprecated and will be removed in the future.
+          description: If set to true, the QRCode will contain the old url format. This is only relevant if the accept header is set to `image/png`. This option is available to provide a grace period for all apps to support the new QR code format and will be removed in the future.
           required: false
           schema:
             type: boolean


### PR DESCRIPTION
# Readiness checklist

- [ ] I added/updated tests.
- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [x] I self-reviewed the PR.

# Description

This is breaking as integrators have to actively change the behavior if they want to use the old reference format in QR codes.