### PR TITLE
Deep queries are incorrectly implemented in the SDK

### DIFF
--- a/packages/sdk/src/types/messages/requests/GetMessagesRequest.ts
+++ b/packages/sdk/src/types/messages/requests/GetMessagesRequest.ts
@@ -2,10 +2,12 @@ export interface GetMessagesRequest {
     createdBy?: string | string[];
     createdByDevice?: string | string[];
     createdAt?: string | string[];
-    recipients?: { address?: string | string[]; relationshipId: string | string[] };
+    recipients?: { address?: string | string[]; relationshipId?: string | string[] };
     participant?: string | string[];
     attachments?: string | string[];
-    contentType?: string | string[];
-    contentSubject?: string | string[];
-    contentBody?: string | string[];
+    content?: {
+        "@type"?: string | string[];
+        subject?: string | string[];
+        body?: string | string[];
+    };
 }

--- a/packages/sdk/src/types/relationships/requests/GetRelationshipsRequest.ts
+++ b/packages/sdk/src/types/relationships/requests/GetRelationshipsRequest.ts
@@ -1,5 +1,5 @@
 export interface GetRelationshipsRequest {
-    templateId?: string | string[];
+    "template.id"?: string | string[];
     peer?: string | string[];
     status?: string | string[];
 }

--- a/test/messages.test.ts
+++ b/test/messages.test.ts
@@ -128,12 +128,12 @@ describe("Message query", () => {
             .addDateSet("createdAt")
             .addStringSet("createdBy")
             .addStringSet("recipients.address", message.recipients[0].address)
+            .addStringSet("recipients.relationshipId", message.recipients[0].relationshipId)
             .addStringSet("content.@type")
             .addStringSet("content.subject")
             .addStringSet("content.body")
             .addStringSet("createdByDevice")
             .addStringArraySet("attachments")
-            .addStringArraySet("relationshipIds")
             .addSingleCondition({
                 key: "participant",
                 value: [message.createdBy, "id111111111111111111111111111111111"],


### PR DESCRIPTION
# Readiness checklist

- [ ] I added/updated tests.
- [X] I ensured that the PR title is good enough for the changelog.
- [X] I labeled the PR.
- [X] I self-reviewed the PR.

# Description

The SDK types don't match the runtime types in some deep query scenarios.

