### PR TITLE
Peer is not required in shared Attribute getters of SDK

### DIFF
--- a/packages/sdk/src/endpoints/AttributesEndpoint.ts
+++ b/packages/sdk/src/endpoints/AttributesEndpoint.ts
@@ -66,11 +66,11 @@ export class AttributesEndpoint extends Endpoint {
         return await this.get("/api/v2/Attributes/Own/Repository", request);
     }
 
-    public async getOwnSharedIdentityAttributes(request?: GetOwnSharedIdentityAttributesRequest): Promise<ConnectorHttpResponse<ConnectorAttributes>> {
+    public async getOwnSharedIdentityAttributes(request: GetOwnSharedIdentityAttributesRequest): Promise<ConnectorHttpResponse<ConnectorAttributes>> {
         return await this.get("/api/v2/Attributes/Own/Shared/Identity", request);
     }
 
-    public async getPeerSharedIdentityAttributes(request?: GetPeerSharedIdentityAttributesRequest): Promise<ConnectorHttpResponse<ConnectorAttributes>> {
+    public async getPeerSharedIdentityAttributes(request: GetPeerSharedIdentityAttributesRequest): Promise<ConnectorHttpResponse<ConnectorAttributes>> {
         return await this.get("/api/v2/Attributes/Peer/Shared/Identity", request);
     }
 


### PR DESCRIPTION
# Readiness checklist

- [ ] I added/updated tests.
- [X] I ensured that the PR title is good enough for the changelog.
- [X] I labeled the PR.
- [X] I self-reviewed the PR.
