### PR TITLE
The SDK is not extensible

### DIFF
--- a/packages/sdk/src/ConnectorClient.ts
+++ b/packages/sdk/src/ConnectorClient.ts
@@ -38,7 +38,7 @@ export class ConnectorClient {
     public readonly relationshipTemplates: RelationshipTemplatesEndpoint;
     public readonly tokens: TokensEndpoint;
 
-    private constructor(config: ConnectorConfig) {
+    protected constructor(config: ConnectorConfig) {
         const axiosInstance = axios.create({
             baseURL: config.baseUrl,
             headers: {


### PR DESCRIPTION
# Readiness checklist

- [ ] I added/updated tests.
- [X] I ensured that the PR title is good enough for the changelog.
- [X] I labeled the PR.
- [X] I self-reviewed the PR.

# Description

To allow the SDK to be extended in custom modules, the connectorClient's constructor is set to protected (currently private).
