### PR TITLE
Runtime types are not exported from the connector SDK

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,7 +1,6 @@
+export * from "@nmshd/runtime-types";
 export * from "./authentication";
 export * from "./ConnectorClient";
 export * from "./ConnectorClientConfig";
 export * from "./jsonSchemaDefinition";
 export * from "./types";
-
-export * from "@nmshd/runtime-types";

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -3,3 +3,5 @@ export * from "./ConnectorClient";
 export * from "./ConnectorClientConfig";
 export * from "./jsonSchemaDefinition";
 export * from "./types";
+
+export * from "@nmshd/runtime-types";


### PR DESCRIPTION
# Readiness checklist

- [ ] I added/updated tests.
- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [x] I self-reviewed the PR.

# Description

It doesn't feel right to directly import those types from the runtime-types when using the sdk.