### PR TITLE
SSE is not reconnecting after a 5xx HTTP error code

### DIFF
--- a/src/modules/sse/SseModule.ts
+++ b/src/modules/sse/SseModule.ts
@@ -27,7 +27,7 @@ export class SseModule extends ConnectorRuntimeModule<SseModuleConfiguration> {
             try {
                 this.eventSource.close();
             } catch (error) {
-                this.logger.error("Failed to close event source", error);
+                this.logger.error("Failed to close event source", JSON.stringify(error));
             }
         }
 


### PR DESCRIPTION
# Readiness checklist

- [ ] I added/updated tests.
- [ ] I ensured that the PR title is good enough for the changelog.
- [ ] I labeled the PR.
- [ ] I self-reviewed the PR.

# Description

As described in https://stackoverflow.com/a/54385402/10029378 EventSources completely drop the connection if a 502 occurred. As restarts in the backbone _can_ cause 5xx HTTP errors we have to properly check the EventSource if it's still running and if not do a manual reconnect.

Additionally this PR introduces a fallback for the time SSE is not available and syncs every 3 seconds.