### PR TITLE
The owner property is missing in the openapi doc of the files endpoint

### DIFF
--- a/src/modules/coreHttpApi/openapi.yml
+++ b/src/modules/coreHttpApi/openapi.yml
@@ -5571,6 +5571,9 @@ components:
           enum: [true]
           nullable: true
           description: true if the ownership of the file is locked, undefined otherwise. If the ownership is locked, the ownership token cannot be used to transfer the ownership of this file and would have to be regenerated for this purpose. This will always be undefined if the file is not owned by the current identity.
+        owner:
+          allOf:
+            - $ref: "#/components/schemas/Address"
       required:
         - id
         - title

--- a/src/modules/coreHttpApi/openapi.yml
+++ b/src/modules/coreHttpApi/openapi.yml
@@ -5586,6 +5586,7 @@ components:
         - mimetype
         - isOwn
         - truncatedReference
+        - owner
 
     FileReferenceTruncated:
       type: object


### PR DESCRIPTION
# Readiness checklist

- [ ] I added/updated tests.
- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [x] I self-reviewed the PR.

# Description

Caused by https://github.com/nmshd/runtime/pull/784